### PR TITLE
Use GCP Filestore for home directories

### DIFF
--- a/deployments/dev.pangeo.io/config/develop.yaml
+++ b/deployments/dev.pangeo.io/config/develop.yaml
@@ -2,6 +2,7 @@ homeDirectories:
   nfs:
     # Output from gcloud beta filestore instances describe dev-home --location=us-central1-b
     serverIP: 10.171.161.186
+    serverName: test
 jupyterhub:
   proxy:
     https:

--- a/deployments/dev.pangeo.io/config/develop.yaml
+++ b/deployments/dev.pangeo.io/config/develop.yaml
@@ -1,3 +1,7 @@
+homeDirectories:
+  nfs:
+    # Output from gcloud beta filestore instances describe dev-home --location=us-central1-b
+    serverIP: 10.171.161.186
 jupyterhub:
   proxy:
     https:

--- a/pangeo-deploy/templates/home-storage.yaml
+++ b/pangeo-deploy/templates/home-storage.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-home-nfs
+spec:
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: {{ .Values.homeDirectories.nfs.serverIP | quote}}
+    path: {{ .Values.homeDirectories.nfs.serverPath | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: home-nfs
+spec:
+  accessModes:
+    - ReadWriteMany
+  # Match name of PV
+  volumeName: {{ .Release.Name }}-home-nfs
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Mi

--- a/pangeo-deploy/templates/home-storage.yaml
+++ b/pangeo-deploy/templates/home-storage.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteMany
   nfs:
     server: {{ .Values.homeDirectories.nfs.serverIP | quote}}
-    path: {{ .Values.homeDirectories.nfs.serverPath | quote }}
+    path: "/{{ .Values.homeDirectories.nfs.serverName }}"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -18,6 +18,21 @@ jupyterhub:
   # See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/values.yaml
 
   singleuser:
+    initContainers:
+      - name: volume-mount-hack
+        image: busybox
+        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: "home/{username}"
+    storage:
+      type: static
+      static:
+        pvcName: home-nfs
+        subPath: "home/{username}"
     image:
       name: pangeo/notebook
       tag: 2018-06-13.4

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -34,3 +34,7 @@ jupyterhub:
   prePuller:
     hook:
       enabled: false
+
+homeDirectories:
+  nfs:
+    serverPath: "/homes"


### PR DESCRIPTION
- Add PV & PVC objects for NFS volume in pangeo-deploy chart
- Use an initContainer per user pod to change permissions on
  home directory for that user.
- Mount home directories for all users from the same PVC

I'll have to think through the security aspects of this, but
it works now.

Ref #25 