### PR TITLE
remove circleci environment caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,6 @@ jobs:
             apt-get update --yes -qq
             apt-get install --yes -qq python3 python3-venv git-crypt jq
       - checkout
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
This might be interfering with updating the environment. Is it possible that the cache itself is somehow overwriting the `install dependencies` section of the circleci config?