### PR TITLE
Use correct meta-chart name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,12 +139,12 @@ jobs:
       - run:
           name: Deploy dev.pangeo.io
           command: |
-            hubploy deploy dev.pangeo.io hub ${CIRCLE_BRANCH}
+            hubploy deploy dev.pangeo.io pangeo-deploy ${CIRCLE_BRANCH}
 
       - run:
           name: Deploy ocean.pangeo.io
           command: |
-            hubploy deploy ocean.pangeo.io hub ${CIRCLE_BRANCH}
+            hubploy deploy ocean.pangeo.io pangeo-deploy ${CIRCLE_BRANCH}
 
 workflows:
   version: 2


### PR DESCRIPTION
For this repo, the name of the meta-chart is 'pangeo-deploy',
not 'hub'. A copypaste holdover, I think.