### PR TITLE
Turn off HTTPS & IP pinning

### DIFF
--- a/deployments/dev/config/prod.yaml
+++ b/deployments/dev/config/prod.yaml
@@ -1,10 +1,9 @@
 jupyterhub:
   proxy:
     https:
+      enabled: false
       hosts:
       - hub.pangeo.io
       letsencrypt:
         contactEmail: dludwig@anaconda.com
-    service:
-      loadBalancerIP: 35.224.250.69
 

--- a/deployments/dev/config/staging.yaml
+++ b/deployments/dev/config/staging.yaml
@@ -1,9 +1,8 @@
 jupyterhub:
   proxy:
     https:
+      enabled: false
       hosts:
       - staging.pangeo.io
       letsencrypt:
         contactEmail: dludwig@anaconda.com
-    service:
-      loadBalancerIP: 104.197.224.206

--- a/deployments/ocean/config/staging.yaml
+++ b/deployments/ocean/config/staging.yaml
@@ -1,9 +1,8 @@
 jupyterhub:
   proxy:
     https:
+      enabled: false
       hosts:
       - ocean.pangeo.io
       letsencrypt:
         contactEmail: raphael.dussin@gmail.com
-    service:
-      loadBalancerIP: 104.154.85.139


### PR DESCRIPTION
Since we changed the names of the deployment,
we end up with new namespaces & service IPs. DNS isn't
set up properly for these yet, so we would have to turn HTTPS
off for now.

Note that this doesn't mess with any user storage, since that
stays under the same prefix as before.