### PR TITLE
Upgrade version of helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: Install helm
           command: |
-            curl https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz | \
+            curl https://storage.googleapis.com/kubernetes-helm/helm-v2.12.0-linux-amd64.tar.gz | \
               tar -xzf -
             mv linux-amd64/helm /usr/local/bin
             helm init --client-only


### PR DESCRIPTION
Makes it easier for people to debug helm locally,
since server (tiller) and client version need to
match.