### PR TITLE
Bump hubploy version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-            # Install repo2docker explicitly since we want a higher version than the released
-            # Can't put this in requirements.txt since pip doesn't seem to realize this is a newer version
-            # This branch combines upstream/master with yuvipanda/julia-requirements-no-verseioneer
-            pip install --upgrade --force-reinstall git+https://github.com/jhamman/repo2docker@pangeo_hubploy
             echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
+
       - setup_remote_docker
       - save_cache:
           paths:
@@ -73,12 +70,6 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-
-            # Install repo2docker explicitly since we want a higher version than the released
-            # Can't put this in requirements.txt since pip doesn't seem to realize this is a newer version
-            # This branch combines upstream/master with yuvipanda/julia-requirements-no-verseioneer
-            pip install --upgrade --force-reinstall git+https://github.com/jhamman/repo2docker@pangeo_hubploy
-            echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
 
             curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -C venv/ -xzf -
             curl -sSL https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator > venv/bin/aws-iam-authenticator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/yuvipanda/hubploy.git@a669af1
+git+https://github.com/yuvipanda/hubploy.git@f3e26f1409d94320d1cc7690daacc23a6a465c06
 pygithub


### PR DESCRIPTION
repo2docker 0.8 was released, so no need to explicitly
install it.