### PR TITLE
add NFS homeDirectories section to ocean

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -9,12 +9,12 @@ jupyterhub:
         volumeMounts:
         - name: home
           mountPath: /home/jovyan
-          subPath: "home/dev.pangeo.io/{username}"
+          subPath: "home/pangeo-users/{username}"
     storage:
       type: static
       static:
         pvcName: home-nfs
-        subPath: "home/dev.pangeo.io/{username}"
+        subPath: "home/pangeo-users/{username}"
     cloudMetadata:
       enabled: true
     cpu:

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -9,12 +9,12 @@ jupyterhub:
         volumeMounts:
         - name: home
           mountPath: /home/jovyan
-          subPath: "home/ocean.pangeo.io/{username}"
+          subPath: "home/pangeo-users/{username}"
     storage:
       type: static
       static:
         pvcName: home-nfs
-        subPath: "home/ocean.pangeo.io/{username}"
+        subPath: "home/pangeo-users/{username}"
     cloudMetadata:
       enabled: true
   hub:
@@ -72,4 +72,8 @@ jupyterhub:
         - raphaeldussin
         - rabernat
         - jhamman
-
+homeDirectories:
+  nfs:
+    # Output from gcloud beta filestore instances describe dev-home --location=us-central1-b
+    serverIP: 10.171.161.186
+    serverName: test


### PR DESCRIPTION
This fixes #84.

In this PR, I have chosen the path on the nfs server called `home/pangeo-users/{username}` in which to place the user home directories. The idea is that **the same directory will be used on all clusters from the same region**. I chose this because, I personally plan to log in all these clusters, and I would like to see the same home directory.

I would like some feedback on whether this is the right choice.