### PR TITLE
Revert "add NFS homeDirectories section to ocean"

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -9,12 +9,12 @@ jupyterhub:
         volumeMounts:
         - name: home
           mountPath: /home/jovyan
-          subPath: "home/pangeo-users/{username}"
+          subPath: "home/dev.pangeo.io/{username}"
     storage:
       type: static
       static:
         pvcName: home-nfs
-        subPath: "home/pangeo-users/{username}"
+        subPath: "home/dev.pangeo.io/{username}"
     cloudMetadata:
       enabled: true
     cpu:

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -9,12 +9,12 @@ jupyterhub:
         volumeMounts:
         - name: home
           mountPath: /home/jovyan
-          subPath: "home/pangeo-users/{username}"
+          subPath: "home/ocean.pangeo.io/{username}"
     storage:
       type: static
       static:
         pvcName: home-nfs
-        subPath: "home/pangeo-users/{username}"
+        subPath: "home/ocean.pangeo.io/{username}"
     cloudMetadata:
       enabled: true
   hub:
@@ -72,8 +72,4 @@ jupyterhub:
         - raphaeldussin
         - rabernat
         - jhamman
-homeDirectories:
-  nfs:
-    # Output from gcloud beta filestore instances describe dev-home --location=us-central1-b
-    serverIP: 10.171.161.186
-    serverName: test
+


### PR DESCRIPTION
Reverts pangeo-data/pangeo-cloud-federation#87

#87 failed with the following error:

```
Error: UPGRADE FAILED: PersistentVolume "ocean-staging-home-nfs" is invalid: spec.persistentvolumesource: Forbidden: is immutable after creation
Traceback (most recent call last):
  File "/root/repo/venv/bin/hubploy", line 11, in <module>
    load_entry_point('hubploy==0.1.0', 'console_scripts', 'hubploy')()
  File "/root/repo/venv/lib/python3.6/site-packages/hubploy/__main__.py", line 57, in main
    helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version)
  File "/root/repo/venv/lib/python3.6/site-packages/hubploy/helm.py", line 127, in deploy
    version
  File "/root/repo/venv/lib/python3.6/site-packages/hubploy/helm.py", line 57, in helm_upgrade
    subprocess.check_call(cmd)
  File "/usr/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['helm', 'upgrade', '--wait', '--install', '--namespace', 'ocean-staging', 'ocean-staging', 'pangeo-deploy', '-f', 'deployments/ocean/config/common.yaml', '-f', 'deployments/ocean/config/staging.yaml', '-f', 'deployments/ocean/secrets/staging.yaml', '--set', 'jupyterhub.singleuser.image.tag=64ce6b3', '--set', 'jupyterhub.singleuser.image.name=us.gcr.io/pangeo-181919/ocean-pangeo-io-notebook']' returned non-zero exit status 1.
Exited with code 1
```