### PR TITLE
make builds always run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,16 +39,19 @@ jobs:
               echo "export COMMIT_RANGE='${COMMIT_RANGE}'" >> ${BASH_ENV}
       - run:
           name: Test building dev.pangeo.io image if needed
+          when: always
           command: |
             hubploy build dev --commit-range ${COMMIT_RANGE}
 
       - run:
           name: Test building ocean.pangeo.io image if needed
+          when: always
           command: |
             hubploy build ocean --commit-range ${COMMIT_RANGE}
 
       - run:
           name: Test building nasa.pangeo.io image if needed
+          when: always
           command: |
             hubploy build nasa --commit-range ${COMMIT_RANGE}
           environment:
@@ -115,16 +118,19 @@ jobs:
 
       - run:
           name: Build dev.pangeo.io image if needed
+          when: always
           command: |
             hubploy build dev --commit-range ${COMMIT_RANGE} --push
 
       - run:
           name: Build ocean.pangeo.io image if needed
+          when: always
           command: |
             hubploy build ocean --commit-range ${COMMIT_RANGE} --push
 
       - run:
           name: Build nasa.pangeo.io image if needed
+          when: always
           command: |
             hubploy build nasa --commit-range ${COMMIT_RANGE} --push
           environment:
@@ -142,16 +148,19 @@ jobs:
 
       - run:
           name: Deploy dev.pangeo.io
+          when: always
           command: |
             hubploy deploy dev pangeo-deploy ${CIRCLE_BRANCH}
 
       - run:
           name: Deploy ocean.pangeo.io
+          when: always
           command: |
             hubploy deploy ocean pangeo-deploy ${CIRCLE_BRANCH}
 
       - run:
           name: Deploy nasa.pangeo.io
+          when: always
           command: |
             hubploy deploy nasa pangeo-deploy ${CIRCLE_BRANCH}
 


### PR DESCRIPTION
This should make it so all clusters always try to build / deploy regardless of the exit status of the others. 