### PR TITLE
Add 'when: always' to helm install too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
 
       - run:
           name: Install helm
+          when: always
           command: |
             curl https://storage.googleapis.com/kubernetes-helm/helm-v2.12.0-linux-amd64.tar.gz | \
               tar -xzf -


### PR DESCRIPTION
We wanna run all the steps regardless of prior failings. This
lets us iterate on ocean.pangeo.io without being blocked by
NASA pangeo.