### PR TITLE
fixed cluster name for icesat2 deployment

### DIFF
--- a/deployments/icesat2/hubploy.yaml
+++ b/deployments/icesat2/hubploy.yaml
@@ -13,5 +13,5 @@ cluster:
   aws:
     project: 783380859522
     service_key: aws-config.txt
-    cluster: pangeo
+    cluster: pangeo-eksctl
     zone: us-west-2


### PR DESCRIPTION
ran into error deploying to AWS ECR:
```
docker.errors.APIError: 500 Server Error: Internal Server Error ("name unknown: The repository with name 'pangeo' does not exist in the registry with id '783380859522'")
Exited with code 1
```
This was because we hadn't yet 'created' the ECR repo (under AWS EKS web console)

Also the following error appears if you don't have the correct cluster name in hubploy.yaml:
```
  File "/usr/local/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['aws', 'eks', 'update-kubeconfig', '--name', 'pangeo', '--region', 'us-west-2']' returned non-zero exit status 255.
Exited with code 1
```