### PR TITLE
switch to notebook

### DIFF
--- a/deployments/ocean/image/binder/Dockerfile
+++ b/deployments/ocean/image/binder/Dockerfile
@@ -1,4 +1,2 @@
 # Note that there must be a tag
-FROM pangeo/pangeo-ocean:2019.03.12
-
-RUN pip install jupyterhub==0.9.4
+FROM pangeo/pangeo-notebook:2019.04.01


### PR DESCRIPTION
If this works, we can drop the pangeo-ocean docker image completely.