### PR TITLE
changed load balancer ip

### DIFF
--- a/deployments/icesat2/config/prod.yaml
+++ b/deployments/icesat2/config/prod.yaml
@@ -8,7 +8,7 @@ pangeo:
         letsencrypt:
           contactEmail: scottyh@uw.edu
       service:
-        loadBalancerIP: a056536ae571b11e9a9ef06d2bcc51c9-236223839.us-west-2.elb.amazonaws.com
+        loadBalancerIP: aa19367a4573811e9a9ef06d2bcc51c9-1125496385.us-west-2.elb.amazonaws.com
     auth:
       github:
         callbackUrl: "https://icesat2.pangeo.io/hub/oauth_callback"


### PR DESCRIPTION
had to re-deploy production cluster manually because it seems that circleci failing due to a timeout on the first deployment lead to a `helm list` STATUS=FAILED.  apparently this condition leads to a number of issues (https://github.com/helm/helm/issues/3353#issuecomment-469109854). So we solved this pickle by removing the failed jupyterhub and re-deploying locally:

1) remove failed cluster
```bash
helm delete icesat2-prod --purge
kubectl delete namespace icesat2-prod
```

2) comment out this file
https://github.com/pangeo-data/pangeo-cloud-federation/blob/prod/deployments/icesat2/config/prod.yaml

3) initial helm deploy (run from local `pangeo-cloud-federation` directory)
```
RELEASE=icesat2
helm upgrade --install --namespace $RELEASE-prod $RELEASE-prod pangeo-deploy -f deployments/$RELEASE/config/common.yaml -f deployments/$RELEASE/config/prod.yaml -f deployments/$RELEASE/secrets/prod.yaml --set pangeo.jupyterhub.singleuser.image.tag=2035c99 --set pangeo.jupyterhub.singleuser.image.name=783380859522.dkr.ecr.us-west-2.amazonaws.com/pangeo --timeout 3000
```

4) added in loadBalancerIP (from `kubectl --namespace=icesat2-prod get svc`) to 
https://github.com/pangeo-data/pangeo-cloud-federation/blob/prod/deployments/icesat2/config/prod.yaml


5) re-run helm command from step 3)
```
RELEASE=icesat2
helm upgrade --install --namespace $RELEASE-prod $RELEASE-prod pangeo-deploy -f deployments/$RELEASE/config/common.yaml -f deployments/$RELEASE/config/prod.yaml -f deployments/$RELEASE/secrets/prod.yaml --set pangeo.jupyterhub.singleuser.image.tag=2035c99 --set pangeo.jupyterhub.singleuser.image.name=783380859522.dkr.ecr.us-west-2.amazonaws.com/pangeo --timeout 3000
```

this might prevent the situation from reoccurring in the future:
https://github.com/yuvipanda/hubploy/issues/17