### PR TITLE
customizing the cluster configuration

### DIFF
--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -29,6 +29,8 @@ pangeo:
           - bartnijssen
           - arbennett
     hub:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
       extraConfig:
         profile_list: |
           c.KubeSpawner.profile_list = [

--- a/deployments/hydro/config/staging.yaml
+++ b/deployments/hydro/config/staging.yaml
@@ -8,3 +8,11 @@ pangeo:
           contactEmail: jhamman@ucar.edu
       service:
         loadBalancerIP: 35.238.0.56
+    hub:
+      resources:
+        requests:
+          cpu: "0.25"
+          memory: 1Gi
+        limits:
+          cpu: "1.25"
+          memory: 1Gi

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -36,6 +36,12 @@ pangeo:
       hook:
         enabled: false
 
+    scheduling:
+        userScheduler:
+          enabled: false
+        userPlaceholder:
+          enabled: false
+
 homeDirectories:
   nfs:
     enabled: false


### PR DESCRIPTION
This does three main things:
- turn off user scheduling
- pin hydro hub to default-pool
- explicit hub memory/cpu requests

We currently have the hubs in a default pool with machine type: n1-standard-2 (2 vCPUs, 7.5 GB memory). I'm trying to fit each deployment onto a single machine. BTW, this equates to roughly $50/mo per deployment (staging/prod hubs).   