### PR TITLE
update ocean image

### DIFF
--- a/deployments/ocean/image/binder/Dockerfile
+++ b/deployments/ocean/image/binder/Dockerfile
@@ -1,2 +1,2 @@
 # Note that there must be a tag
-FROM pangeo/pangeo-notebook:2019.04.01
+FROM pangeo/pangeo-notebook:2019.04.19


### PR DESCRIPTION
Is this still the right way to point to the docker image? Or can our new "base image" magic help us with this somehow?