### PR TITLE
Change installed SUMMA version to ignore time offset

### DIFF
--- a/deployments/hydro/image/binder/postBuild
+++ b/deployments/hydro/image/binder/postBuild
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-git clone --single-branch -b develop https://github.com/ncar/summa.git
+git clone -b develop https://github.com/ncar/summa.git
 
 cd summa
-git checkout -b whw2019 b074b0
+git checkout -b cewa564_pangeo b074b0
+# Add the commit from Andrew that sets the time offset to 0
+git cherry-pick 3516fe2
 
 export F_MASTER=${PWD}
 export FC="gfortran"


### PR DESCRIPTION
Also includes an update to the installed version of pysumma (but uses the same tag, so not change here).