### PR TITLE
first pass at getting dask workers to share user home directory

### DIFF
--- a/deployments/nasa/image/binder/dask_config.yaml
+++ b/deployments/nasa/image/binder/dask_config.yaml
@@ -39,8 +39,6 @@ kubernetes:
           - name: nfs
             mountPath: /home/jovyan
             subPath: "nasa.pangeo.io/home/${JUPYTERHUB_USER}"
-        nodeSelector:
-          k8s.io/cluster-autoscaler/node-template/label/spot: "true"
       volumes:
         - name: nfs
           persistentVolumeClaim:

--- a/deployments/nasa/image/binder/dask_config.yaml
+++ b/deployments/nasa/image/binder/dask_config.yaml
@@ -35,6 +35,18 @@ kubernetes:
           requests:
             cpu: 1
             memory: 7G
+        volumeMounts:
+          - name: nfs
+            mountPath: /home/jovyan
+            subPath: "nasa.pangeo.io/home/${JUPYTERHUB_USER}"
+        nodeSelector:
+          k8s.io/cluster-autoscaler/node-template/label/spot: "true"
+      volumes:
+        - name: nfs
+          persistentVolumeClaim:
+            claimName: home-nfs
+
+
 
 labextension:
   factory:


### PR DESCRIPTION
@yuvipanda @jhamman - i'm getting fairly confused with PVs, PVCs, volumes, NFS, EFS. But this seems like it should accomplish dask workers having access to a users home directory. 

Reminder - this needed to share custom conda environments and (maybe?) a users credentials in ~/.aws