### PR TITLE
remove nodeSelectors from remaining GKE hubs

### DIFF
--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -36,8 +36,6 @@ pangeo:
         limits:
           cpu: "1.25"
           memory: 1Gi
-      nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
       extraConfig:
         profile_list: |
           c.KubeSpawner.profile_list = [
@@ -102,9 +100,6 @@ pangeo:
         - mountPath: /usr/local/share/jupyterhub/static/extra-assets
           name: custom-templates
           subPath: "pangeo-custom-jupyterhub-templates/extra-assets"
-    proxy:
-      nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
 
 homeDirectories:
   nfs:

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -26,8 +26,6 @@ pangeo:
         limits:
           cpu: "1.25"
           memory: 1Gi
-      nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
       extraConfig:
         profile_list: |
           c.KubeSpawner.profile_list = [
@@ -89,9 +87,6 @@ pangeo:
         - mountPath: /usr/local/share/jupyterhub/static/extra-assets
           name: custom-templates
           subPath: "pangeo-custom-jupyterhub-templates/extra-assets"
-    proxy:
-      nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
 
 homeDirectories:
   nfs:


### PR DESCRIPTION
Moving hubs to new `core-pool` and using built in node selectors (see #264).