### PR TITLE
require dev user pods in jupyter pool

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -24,6 +24,10 @@ pangeo:
       memory:
         limit: 14G
         guarantee: 4G
+    scheduling:
+      userPods:
+        nodeAffinity:
+          matchNodePurpose: require
     hub:
       resources:
         requests:


### PR DESCRIPTION
this requires that the node purpose label match for user pods to be scheduled. Merging to test.