### PR TITLE
avoid pip

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -2,6 +2,5 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - pip:
-    - dask-labextension==0.3.1
-    - nbgitpuller
+  - dask-labextension==0.3.1
+  - nbgitpuller


### PR DESCRIPTION
pip installing in a conda env may clobber some of the dependencies installed with conda and cause problems. (Sometimes things just works but it is 50-50 change.)

PS: In a future PR I'm planning on adding the `defaults` channel below conda-forge here. In the past we did recommend removing `defaults` but since conda >=4.6 we have a better strategy to handle binary incompatibility issues with the `strict` channel option. (Environments are more reliable and stable that way.)