### PR TITLE
Switch to multiple git-crypt keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,18 @@ jobs:
           key: v2-dependencies-gcloud-226-{{ checksum "requirements.txt" }}
 
       - run:
-          name: Unlock our secrets
+          name: Unlock default secrets
           command: |
-            echo "${GIT_CRYPT_KEY}" | base64 -d > ~/repo/key
-            git crypt unlock ~/repo/key
-            rm ~/repo/key
+            echo "${GIT_CRYPT_KEY}" | base64 -d > ~/repo/default.key
+            git crypt unlock ~/repo/default.key
+            rm ~/repo/default.key
+
+      - run:
+          name: Unlock ooi secrets
+          command: |
+            echo "${OOI_GIT_CRYPT_KEY}" | base64 -d > ~/repo/ooi.key
+            git crypt unlock ~/repo/ooi.key
+            rm ~/repo/ooi.key
 
       - run:
           name: Build dev.pangeo.io image if needed

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
-deployments/*/secrets/** filter=git-crypt diff=git-crypt
+deployments/ocean/secrets/** filter=git-crypt diff=git-crypt
+deployments/dev/secrets/** filter=git-crypt diff=git-crypt
+deployments/icesat2/secrets/** filter=git-crypt diff=git-crypt
+deployments/hydro/secrets/** filter=git-crypt diff=git-crypt
+deployments/nasa/secrets/** filter=git-crypt diff=git-crypt
+deployments/ooi/secrets/** filter=git-crypt-ooi diff=git-crypt-ooi


### PR DESCRIPTION
This pull request is a suggested route to having multiple git-crypt keys in use for deployment secrets. I have done a fair amount of testing with git-crypt and multiple keys [here](https://github.com/tjcrone/git-crypt-testing), and I think this is something that would be relatively easy and safe to do. More on git-crypt with multiple keys [here](https://github.com/AGWA/git-crypt/blob/master/doc/multiple_keys.md). Anyway, I thought I would open up a pull request to get this conversation started since everyone loves that sort of thing.

For now, I think it should be easy and safe to have all new deployments provided with their own git-crypt key to avoid any more cross-fertilization. Eventually it is probably worth moving off of the default key altogether and giving all deployments their own key. This would need to be done carefully to prevent the publication of secrets. Also doable though.

Any thoughts?