### PR TITLE
Update ocean environment.yml to include xmitgcm

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - pip:
     - dask-labextension==0.3.1
     - nbgitpuller
+    - xmitgcm=>0.4.1


### PR DESCRIPTION
This will allow us to use the new llcreader module with the ECCO cloud data sets.