### PR TITLE
adding fsspec and pinning holoviews

### DIFF
--- a/deployments/esip/image/binder/environment.yml
+++ b/deployments/esip/image/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - keras
   - pytorch-cpu
   # pyviz
-  - holoviews
+  - holoviews=1.12.1
   - panel
   - geoviews
   - hvplot
@@ -51,6 +51,7 @@ dependencies:
   - lz4
   - gcsfs
   - s3fs
+  - fsspec
   # jupyter-related
   - ipyleaflet
   # xarray-related


### PR DESCRIPTION
Pinning `holoviews=1.12.1` is required to get hover to display lon/lat correctly until https://github.com/pyviz/holoviews/issues/3820 is fixed. 

Adding `fsspec` to try [reading zarr data from a web server](https://gist.github.com/rabernat/cb822b190619e7368f834a16deef41e3).