### PR TITLE
remove nodeselectors from nasa.pangeo.io

### DIFF
--- a/deployments/nasa/config/common.yaml
+++ b/deployments/nasa/config/common.yaml
@@ -1,5 +1,12 @@
 pangeo:
   jupyterhub:
+    scheduling:
+      userPods:
+        nodeAffinity:
+          matchNodePurpose: require
+      corePods:
+        nodeAffinity:
+          matchNodePurpose: require
     singleuser:
       initContainers:
         - name: volume-mount-hack
@@ -54,8 +61,6 @@ pangeo:
 
       cloudMetadata:
         enabled: true
-      nodeSelector:
-        alpha.eksctl.io/nodegroup-name: user-notebook
       cpu:
         limit: 4
         guarantee: 3
@@ -82,17 +87,14 @@ pangeo:
           - "pangeo-data"
       scopes:
         - "read:user"
+        - "user:email"
         - "read:org"
       admin:
         access: true
         users:
           - scottyhq
           - jhamman
-          - apawloski
           - amanda-tan
-    proxy:
-      nodeSelector:
-        alpha.eksctl.io/nodegroup-name: hub
     hub:
       resources:
         requests:
@@ -101,8 +103,6 @@ pangeo:
         limits:
           cpu: "1.25"
           memory: 1Gi
-      nodeSelector:
-        alpha.eksctl.io/nodegroup-name: hub
       extraConfig:
         cloneRepo: |
           # Hack solution for branding

--- a/deployments/nasa/image/binder/Dockerfile
+++ b/deployments/nasa/image/binder/Dockerfile
@@ -1,2 +1,0 @@
-# Note that there must be a tag
-FROM pangeo/pangeo-notebook-onbuild:2019.07.01

--- a/deployments/nasa/image/binder/dask_config.yaml
+++ b/deployments/nasa/image/binder/dask_config.yaml
@@ -11,10 +11,10 @@ distributed:
 
 kubernetes:
   name: dask-{JUPYTERHUB_USER}-{uuid}
+  env:
+    NB_PYTHON_PREFIX: ${NB_PYTHON_PREFIX}
   worker-template:
     spec:
-      nodeSelector:
-        alpha.eksctl.io/nodegroup-name: dask-worker
       restartPolicy: Never
       containers:
         - name: dask-${JUPYTERHUB_USER}

--- a/deployments/nasa/image/binder/environment.yml
+++ b/deployments/nasa/image/binder/environment.yml
@@ -1,49 +1,46 @@
-name: icesat2
+name: nasa
 channels:
   - conda-forge
 dependencies:
-  - conda=4.6
+  - python=3.7
+  - conda=4.7
+  - nomkl
   - ipykernel=5.1
   - nb_conda_kernels=2.2
-  - nomkl
-  - s3fs=0.2
-  - gcsfs=0.2
-  - intake=0.4
+  - fsspec=0.3
+  - s3fs=0.3
+  - gcsfs=0.3
+  - intake=0.5
   - intake-xarray=0.3
-  - msgpack-python=0.6
-  - curl=7.64
-  - python=3.6
   - xarray=0.12
-  - zarr=2.2
+  - zarr=2.3
   - h5py=2.9
   - h5netcdf=0.7
-  - dask=1.1
-  - distributed=1.25
-  - dask-kubernetes=0.8
-  - matplotlib=3.0
-  - nbserverproxy=0.8.8
-  - jupyter=1.0.0
-  - ipywidgets=7.4
-  - graphviz=2.38
-  - jupyterlab=0.35.4
+  - dask=2.1
+  - distributed=2.1
+  - dask-kubernetes=0.9
+  - matplotlib=3.1
+  - jupyter=1.0
+  - jupyter-server-proxy=1.1
+  - ipywidgets=7.5
+  - graphviz=2.40
+  - jupyterlab=1.0
   - libgdal=2.4
   - boto3=1.9
   - awscli=1.16
   - hvplot=0.4
   - geoviews-core=1.6
-  - ipyleaflet=0.10
-  - datashader=0.6
-  - requests=2.21
-  - pandas=0.24
-  - geopandas=0.4
+  - ipyleaflet=0.11
+  - datashader=0.7
+  - requests=2.22
+  - pandas=0.25
+  - geopandas=0.5
   - rasterio=1.0
-  - pyresample
-  - geocube
-  - rioxarray
-  - regionmask
+  - rio-cogeo=1.1
+  - sat-search=0.2
+  - sat-stac
+  - nbgitpuller=0.6
+  - pip=19.2
   - pip:
-    - rio-cogeo
-    - sat-search==0.2.0
     - dask-labextension==0.3.1
     - git+https://github.com/pangeo-data/intake-stac.git
-    - nbgitpuller

--- a/deployments/nasa/image/binder/postBuild
+++ b/deployments/nasa/image/binder/postBuild
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-jupyter serverextension enable --py nbserverproxy --sys-prefix
 jupyter labextension install @jupyter-widgets/jupyterlab-manager \
-                             @jupyterlab/hub-extension \
                              @pyviz/jupyterlab_pyviz \
                              jupyter-leaflet \
                              dask-labextension

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - xhistogram
   - xmitgcm>=0.4.1
+  - fsspec
   - pip:
     - dask-labextension==0.3.1
     - nbgitpuller


### PR DESCRIPTION
in updating the nasa cluster nodegroups to use affinities and taints like the other hubs I temporarily broke both staging.nasa.pangeo.io and nasa.pangeo.io. I think that the autoscaler is getting confused about the fact that some pods are looking for node labels and others are using the affinity approach. 

 I hope that merging this will fix things. @tjcrone - the change to ocean seems minor, but I just wanted to loop you in!

```
kube-system    tiller-deploy-7b4c999868-94hxk        1/1     Running       0          75m
nasa-prod      autohttps-7b59cc57fd-7h922            0/2     Pending       0          75m
nasa-prod      hub-68bdd797d5-2f9tf                  0/1     Pending       0          63m
nasa-prod      hub-68bdd797d5-hcjdm                  1/1     Terminating   0          6d18h
nasa-prod      proxy-86bb75fc9-l5bcm                 1/1     Terminating   0          6d18h
nasa-prod      proxy-86bb75fc9-q44hb                 0/1     Pending       0          63m
nasa-prod      user-scheduler-8577f7ccdb-x6pz2       1/1     Terminating   0          11h
nasa-prod      user-scheduler-8577f7ccdb-xg2gl       1/1     Running       0          63m
nasa-prod      user-scheduler-8577f7ccdb-xlgr7       1/1     Running       0          88m
nasa-staging   autohttps-5c7b9c9b58-2j9hq            2/2     Running       0          97m
nasa-staging   hub-76bbfc4db-g4hmz                   1/1     Running       0          97m
nasa-staging   proxy-56c6b94475-dj82v                1/1     Running       0          97m
```

autoscaler log snapshot:
```
I0726 03:49:05.250758       1 scale_up.go:407] No pod can fit to eksctl-pangeo-nasa-nodegroup-user-notebook-v2-NodeGroup-104LSTLJEWVSV
I0726 03:49:05.250769       1 utils.go:208] Pod proxy-86bb75fc9-q44hb can't be scheduled on eksctl-pangeo-nasa-nodegroup-dask-worker-v2-NodeGroup-1S8K67F0KSI81, predicate failed: GeneralPredicates predicate mismatch, reason: node(s) didn't match node selector
I0726 03:49:05.250777       1 utils.go:208] Pod hub-68bdd797d5-2f9tf can't be scheduled on eksctl-pangeo-nasa-nodegroup-dask-worker-v2-NodeGroup-1S8K67F0KSI81, predicate failed: GeneralPredicates predicate mismatch, reason: node(s) didn't match node selector
I0726 03:49:05.250793       1 utils.go:208] Pod autohttps-7b59cc57fd-7h922 can't be scheduled on eksctl-pangeo-nasa-nodegroup-dask-worker-v2-NodeGroup-1S8K67F0KSI81, predicate failed: GeneralPredicates predicate mismatch, reason: node(s) didn't match node selector
I0726 03:49:05.250798       1 scale_up.go:407] No pod can fit to eksctl-pangeo-nasa-nodegroup-dask-worker-v2-NodeGroup-1S8K67F0KSI81
I0726 03:49:05.250804       1 scale_up.go:412] No expansion options
I0726 03:49:05.250847       1 static_autoscaler.go:307] Calculating unneeded nodes
I0726 03:49:05.250855       1 utils.go:500] Skipping ip-192-168-51-88.ec2.internal - no node group config
I0726 03:49:05.250863       1 utils.go:509] Skipping ip-192-168-22-40.ec2.internal - node group min size reached
I0726 03:49:05.250946       1 static_autoscaler.go:333] Scale down status: unneededOnly=false lastScaleUpTime=2019-07-26 02:41:20.535470128 +0000 UTC m=+21.587368221 lastScaleDownDeleteTime=2019-07-26 02:41:20.535470234 +0000 UTC m=+21.587368320 lastScaleDownFailTime=2019-07-26 02:41:20.535470318 +0000 UTC m=+21.587368410 scaleDownForbidden=false isDeleteInProgress=false
I0726 03:49:05.250972       1 static_autoscaler.go:339] Starting scale down
I0726 03:49:05.250999       1 scale_down.go:641] No candidates for scale down
I0726 03:49:05.251126       1 factory.go:33] Event(v1.ObjectReference{Kind:"Pod", Namespace:"nasa-prod", Name:"proxy-86bb75fc9-q44hb", UID:"2e122613-af52-11e9-a0f5-169bb4a1398c", APIVersion:"v1", ResourceVersion:"44790283", FieldPath:""}): type: 'Normal' reason: 'NotTriggerScaleUp' pod didn't trigger scale-up (it wouldn't fit if a new node is added): 3 node(s) didn't match node selector
I0726 03:49:05.251280       1 factory.go:33] Event(v1.ObjectReference{Kind:"Pod", Namespace:"nasa-prod", Name:"hub-68bdd797d5-2f9tf", UID:"2e128945-af52-11e9-a0f5-169bb4a1398c", APIVersion:"v1", ResourceVersion:"44790176", FieldPath:""}): type: 'Normal' reason: 'NotTriggerScaleUp' pod didn't trigger scale-up (it wouldn't fit if a new node is added): 3 node(s) didn't match node selector
I0726 03:49:05.251295       1 factory.go:33] Event(v1.ObjectReference{Kind:"Pod", Namespace:"nasa-prod", Name:"autohttps-7b59cc57fd-7h922", UID:"80e5b7eb-af50-11e9-a0f5-169bb4a1398c", APIVersion:"v1", ResourceVersion:"44790174", FieldPath:""}): type: 'Normal' reason: 'NotTriggerScaleUp' pod didn't trigger scale-up (it wouldn't fit if a new node is added): 3 node(s) didn't match node selector
```
