### PR TITLE
Add erddapy to ocean image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,7 @@ jobs:
           environment:
             PYTHONIOENCODING: utf-8
 
-      # This is currently disabled becauses it always runs, because the Azure
-      # container registry is not open to annonymous read access. This can be changed
-
-      # This is currently disabled becauses it always runs, because the Azure
+      # This is currently disabled becauses it always runs and because the Azure
       # container registry is not open to annonymous read access. This can be changed
       # but it will take some changes to our Azure account to allow this feature in
       # preview mode.

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - xhistogram
   - xmitgcm>=0.4.1
   - fsspec
+  - erddapy


### PR DESCRIPTION
This pull request fixes a minor typo and also adds [erddapy](https://ioos.github.io/erddapy) to the ocean.pangeo.io image.

cc @ocefpaf, @emiliom