### PR TITLE
increase timeout limit to 10 minutes

### DIFF
--- a/deployments/esip/config/common.yaml
+++ b/deployments/esip/config/common.yaml
@@ -8,6 +8,7 @@ pangeo:
         nodeAffinity:
           matchNodePurpose: require
     singleuser:
+      startTimeout: 600
       initContainers:
         - name: volume-mount-hack
           image: busybox

--- a/deployments/icesat2/config/common.yaml
+++ b/deployments/icesat2/config/common.yaml
@@ -8,6 +8,7 @@ pangeo:
         nodeAffinity:
           matchNodePurpose: require
     singleuser:
+      startTimeout: 600
       initContainers:
         - name: volume-mount-hack
           image: busybox


### PR DESCRIPTION
should prevent `Spawn failed: pod/jupyter-scottyhq did not start in 300 seconds!` errors for the first user to spin the cluster up from 0 nodes