### PR TITLE
Add GPU node pool for hydro.pangeo.io

### DIFF
--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -83,6 +83,17 @@ pangeo:
                     'mem_guarantee': '24G',
                     'image': 'jupyter/r-notebook',
                 }
+            },
+            {
+                'display_name': 'Pangeo ML Env - standard (n1-standard-4 | 4 cores, 15GB)',
+                'kubespawner_override': {
+                    'cpu_limit': 4,
+                    'cpu_guarantee': 4,
+                    'mem_limit': '15G',
+                    'mem_guarantee': '15G',
+                    'image': 'pangeo/ml-notebook:latest',
+                    'extra_resource_limits': {nvidia.com/gpu: "1"}
+                }
             }
           ]
         customPodHook: |

--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -83,17 +83,6 @@ pangeo:
                     'mem_guarantee': '24G',
                     'image': 'jupyter/r-notebook',
                 }
-            },
-            {
-                'display_name': 'Pangeo ML Env - standard (n1-standard-4 | 4 cores, 15GB)',
-                'kubespawner_override': {
-                    'cpu_limit': 4,
-                    'cpu_guarantee': 4,
-                    'mem_limit': '15G',
-                    'mem_guarantee': '15G',
-                    'image': 'pangeo/ml-notebook:latest',
-                    'extra_resource_limits': {nvidia.com/gpu: "1"}
-                }
             }
           ]
         customPodHook: |

--- a/pangeo-deploy/requirements.yaml
+++ b/pangeo-deploy/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: pangeo
-  version: "19.07.02-37d387f"
+  version: "19.09.26-dd6574b"
   repository: https://pangeo-data.github.io/helm-chart/
   import-values:
     - child: rbac

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -19,18 +19,12 @@ pangeo:
     # See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/values.yaml
 
     singleuser:
-      image:
-        name: pangeo/base-notebook
-        tag: 2019.02.01
       cpu:
         limit: 2
         guarantee: 1
       memory:
         limit: 4G
         guarantee: 2G
-      defaultUrl: "/lab"
-      cmd: jupyter-labhub
-      serviceAccountName: daskkubernetes
 
     prePuller:
       hook:


### PR DESCRIPTION
This adds the basic config to (hopefully) allow us to use GPUs in our Jupyter sessions. 

I mostly followed https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/994 and https://zero-to-jupyterhub.readthedocs.io/en/latest/user-resources.html?highlight=GPU#set-user-gpu-guarantees-limits (thanks @consideRatio and @yuvipanda!)

With the help of @jsadler2, we now have a alpha docker image with GPU libs in it: https://github.com/pangeo-data/pangeo-stacks/pull/83#issuecomment-535732363

I've added a simple GPU node pool to our cluster, with the following specs:

```
gcloud container node-pools describe --cluster  dev-pangeo-io-cluster  jupyter-gpu-pool                                      ✔  10093  20:59:13
autoscaling:
  enabled: true
  maxNodeCount: 1
config:
  accelerators:
  - acceleratorCount: '1'
    acceleratorType: nvidia-tesla-v100
  diskSizeGb: 100
  diskType: pd-standard
  imageType: COS
  labels:
    hub.jupyter.org/node-purpose: user
  machineType: n1-standard-4
  metadata:
    disable-legacy-endpoints: 'true'
  oauthScopes:
  - https://www.googleapis.com/auth/devstorage.read_only
  - https://www.googleapis.com/auth/logging.write
  - https://www.googleapis.com/auth/monitoring
  - https://www.googleapis.com/auth/servicecontrol
  - https://www.googleapis.com/auth/service.management.readonly
  - https://www.googleapis.com/auth/trace.append
  preemptible: true
  serviceAccount: default
  taints:
  - effect: NO_SCHEDULE
    key: nvidia.com/gpu
    value: 'true'
  - effect: NO_SCHEDULE
    key: hub.jupyter.org_dedicated
    value: user
  - effect: NO_SCHEDULE
    key: nvidia.com/gpu
    value: present
instanceGroupUrls:
- https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-cl-jupyter-gpu-pool-7f5f1975-grp
management:
  autoRepair: true
  autoUpgrade: true
maxPodsConstraint:
  maxPodsPerNode: '110'
name: jupyter-gpu-pool
podIpv4CidrSize: 24
selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/jupyter-gpu-pool
status: RUNNING
version: 1.12.8-gke.10
```

I'm quite sure this is going to take some iteration to get right but putting this up now to get early feedback and/or collect other interested parties.