### PR TITLE
Adding fastparquet to esip staging

### DIFF
--- a/deployments/esip/image/binder/environment.yml
+++ b/deployments/esip/image/binder/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pandas
   - xarray
   - python-gist
+  - fastparquet
   # data science stuff
   - scikit-image
   - scikit-learn


### PR DESCRIPTION
Adding fastparquet so we can read parquet files from object storage into dask dataframe