### PR TITLE
Limit number of worker pods per Dask cluster

### DIFF
--- a/deployments/ocean/image/binder/dask_config.yaml
+++ b/deployments/ocean/image/binder/dask_config.yaml
@@ -10,6 +10,8 @@ distributed:
       limit: 5s
 
 kubernetes:
+  count:
+    max: 100
   worker-template:
     metadata:
     spec:

--- a/deployments/ocean/image/binder/dask_config.yaml
+++ b/deployments/ocean/image/binder/dask_config.yaml
@@ -11,7 +11,7 @@ distributed:
 
 kubernetes:
   count:
-    max: 100
+    max: 30
   worker-template:
     metadata:
     spec:


### PR DESCRIPTION
Users have been crashing ocean.pangeo.io by requesting a large number
of workers. This will limit users to 100 workers.

It's quite easy to work around; a longer-term solution is to use
dask-gateway.

---

If a user does `cluster.scale(400)`, a warning should be printed to the screen saying they requested too many workers.