### PR TITLE
reduce core pool load for GCP clusters

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -34,8 +34,8 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.5"
-          memory: 1Gi
+          cpu: "0.25"
+          memory: 0.5Gi
         limits:
           cpu: "1.25"
           memory: 1Gi

--- a/deployments/dev/config/staging.yaml
+++ b/deployments/dev/config/staging.yaml
@@ -13,3 +13,6 @@ pangeo:
         requests:
           cpu: "0.1"
           memory: 0.25Gi
+    scheduling:
+      userScheduler:
+        enabled: false

--- a/deployments/dev/config/staging.yaml
+++ b/deployments/dev/config/staging.yaml
@@ -11,5 +11,5 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.25"
-          memory: 0.5Gi
+          cpu: "0.1"
+          memory: 0.25Gi

--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -38,8 +38,8 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.5"
-          memory: 1Gi
+          cpu: "0.25"
+          memory: 0.5Gi
         limits:
           cpu: "1.25"
           memory: 1Gi
@@ -83,11 +83,6 @@ pangeo:
                     'mem_guarantee': '2G',
                     'image': 'pangeo/ml-notebook:latest',
                     'extra_resource_limits': {"nvidia.com/gpu": "1"},
-                    # 'tolerations': [
-                    #     {'key': 'hub.jupyter.org/dedicated','operator': 'Equal','value': 'user','effect': 'NoSchedule'},
-                    #     {'key': 'hub.jupyter.org_dedicated','operator': 'Equal','value': 'user','effect': 'NoSchedule'},
-                    #     {'key': 'nvidia.com/gpu','operator': 'Equal','value': 'present','effect': 'NoSchedule'}
-                    # ],
                 }
             },
           ]

--- a/deployments/hydro/config/staging.yaml
+++ b/deployments/hydro/config/staging.yaml
@@ -13,3 +13,6 @@ pangeo:
         requests:
           cpu: "0.1"
           memory: 0.25Gi
+    scheduling:
+      userScheduler:
+        enabled: false

--- a/deployments/hydro/config/staging.yaml
+++ b/deployments/hydro/config/staging.yaml
@@ -11,5 +11,5 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.25"
-          memory: 0.5Gi
+          cpu: "0.1"
+          memory: 0.25Gi

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -28,8 +28,8 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.5"
-          memory: 1Gi
+          cpu: "0.25"
+          memory: 0.5Gi
         limits:
           cpu: "1.25"
           memory: 1Gi

--- a/deployments/ocean/config/staging.yaml
+++ b/deployments/ocean/config/staging.yaml
@@ -13,3 +13,6 @@ pangeo:
         requests:
           cpu: "0.1"
           memory: 0.25Gi
+    scheduling:
+      userScheduler:
+        enabled: false

--- a/deployments/ocean/config/staging.yaml
+++ b/deployments/ocean/config/staging.yaml
@@ -11,5 +11,5 @@ pangeo:
     hub:
       resources:
         requests:
-          cpu: "0.25"
-          memory: 0.5Gi
+          cpu: "0.1"
+          memory: 0.25Gi


### PR DESCRIPTION
@rabernat - I think we can gradually reduce the resources reserved for the hubs on our GCP cluster. The staging hubs in particular. This should help us reduce the load on the core pool and let us scale the size of the node pool from 5 to 3 hubs.