### PR TITLE
Latest intake-esm in ocean.pangio.io

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - ctd
   - geolinks
   - gridgeo
+  - intake-esm
   - ioos-tools
   - pocean-core
   - podaacpy
@@ -21,4 +22,3 @@ dependencies:
     - git+https://github.com/jbusecke/xgcm.git@jbusecke_weighted_average_and_cumsum
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master
-    - git+https://github.com/andersy005/intake-esm.git@refactor

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -19,6 +19,6 @@ dependencies:
   - xlrd
   - xmitgcm>=0.4.1
   - pip:
-    - git+https://github.com/jbusecke/xgcm.git@jbusecke_weighted_average_and_cumsum
+    - git+https://github.com/xgcm/xgcm.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ctd
   - geolinks
   - gridgeo
-  - intake-esm>=2019.10.15
+  - intake-esm
   - ioos-tools
   - pocean-core
   - podaacpy

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - ctd
   - geolinks
   - gridgeo
-  - intake-esm
   - ioos-tools
   - pocean-core
   - podaacpy
@@ -22,3 +21,4 @@ dependencies:
     - git+https://github.com/xgcm/xgcm.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master
+    - intake-esm

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -22,3 +22,4 @@ dependencies:
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master
     - intake-esm
+

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ctd
   - geolinks
   - gridgeo
-  - intake-esm
+  - intake-esm>=2019.10.15
   - ioos-tools
   - pocean-core
   - podaacpy


### PR DESCRIPTION
andersy005 merged and released the changes previously in `https://github.com/andersy005/intake-esm.git@refactor`

In order to use the latest `intake-esm` for the CMIP6 hackathon, this `environment.yml` needs to be updated