### PR TITLE
Add jupyter install step to postbuild

### DIFF
--- a/deployments/ocean/image/binder/postBuild
+++ b/deployments/ocean/image/binder/postBuild
@@ -2,3 +2,4 @@
 
 mkdir -p ${KERNEL_PYTHON_PREFIX}/etc/dask
 cp binder/dask_config.yaml ${KERNEL_PYTHON_PREFIX}/etc/dask/dask.yaml
+jupyter labextension install nbdime-jupyterlab


### PR DESCRIPTION
This will hopefully install the nbdime extension to jupyterlab during the build and avoid prompting the user about it.

Fixes #457 