### PR TITLE
Send individual notification when pipeline fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,9 +266,12 @@ jobs:
       - run:
           name: Deploy ooi.pangeo.io
           when: always
-          command: |
           no_output_timeout: 1200
-            errormsg() { ./.circleci/send-email "tjcrone@gmail.com" "Deployment to ooi-${CIRCLE_BRANCH} failed"; }
+          command: |
+            EMAIL="tjcrone@gmail.com"
+            SUBJECT="CircleCI Error"
+            BODY="Deployment to ooi-${CIRCLE_BRANCH} failed on `date -u +'%D at %T UTC.'`"
+            errormsg() { ./.circleci/send-email "${EMAIL}" "${SUBJECT}" "${BODY}"; }
             trap errormsg ERR
             hubploy deploy ooi pangeo-deploy ${CIRCLE_BRANCH}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,8 +267,10 @@ jobs:
           name: Deploy ooi.pangeo.io
           when: always
           command: |
-            hubploy deploy ooi pangeo-deploy ${CIRCLE_BRANCH}
           no_output_timeout: 1200
+            errormsg() { ./.circleci/send-email "tjcrone@gmail.com" "Deployment to ooi-${CIRCLE_BRANCH} failed"; }
+            trap errormsg ERR
+            hubploy deploy ooi pangeo-deploy ${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/send-email
+++ b/.circleci/send-email
@@ -1,21 +1,15 @@
 #!/usr/bin/env bash
-
-# check number of arguments
-if [ "$#" -ne 2 ]; then
-    echo "Enter an email address and the email body as two arguments."
-    exit
-fi
+# script to send email from CircleCI using SendGrid
+# pass as arguments: email address, email subject, email body
 
 # define message attributes
 SENDER_EMAIL="no-reply@pangeo.io"
 SENDER_NAME="Pangeo"
-SUBJECT="CircleCI Error"
-BODY="${2} on `date -u +'%D at %T UTC.'`"
 
 # send message
 curl --url https://api.sendgrid.com/v3/mail/send \
   --header "Authorization: Bearer $SENDGRID_API_KEY" \
   --header "Content-Type: application/json" \
-  --data '{"personalizations":[{"to":[{"email":"'"${1}"'"}], "subject":"'"${SUBJECT}"'"}], \
+  --data '{"personalizations":[{"to":[{"email":"'"${1}"'"}], "subject":"'"${2}"'"}], \
 "from":{"email":"'"${SENDER_EMAIL}"'","name":"'"${SENDER_NAME}"'"}, \
-"content": [{"type": "text/plain", "value": "'"${BODY}"'"}]}'
+"content": [{"type": "text/plain", "value": "'"${3}"'"}]}'

--- a/.circleci/send-email
+++ b/.circleci/send-email
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# check number of arguments
+if [ "$#" -ne 2 ]; then
+    echo "Enter an email address and the email body as two arguments."
+    exit
+fi
+
+# define message attributes
+SENDER_EMAIL="no-reply@pangeo.io"
+SENDER_NAME="Pangeo"
+SUBJECT="CircleCI Error"
+BODY="${2} on `date -u +'%D at %T UTC.'`"
+
+# send message
+curl --url https://api.sendgrid.com/v3/mail/send \
+  --header "Authorization: Bearer $SENDGRID_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{"personalizations":[{"to":[{"email":"'"${1}"'"}], "subject":"'"${SUBJECT}"'"}], \
+"from":{"email":"'"${SENDER_EMAIL}"'","name":"'"${SENDER_NAME}"'"}, \
+"content": [{"type": "text/plain", "value": "'"${BODY}"'"}]}'


### PR DESCRIPTION
This adds the ability to send an email from inside the CircleCI configuration, and sets up the CircleCI configuration to email me when the OOI deployment pipeline fails. As suggested [here](https://support.circleci.com/hc/en-us/articles/360007444314-Sending-email-from-a-container), this uses SendGrid to send email. We will need to add the Pangeo SendGrid API key to the CircleCI environment variables to make this work.