### PR TITLE
bump dask gateway image version

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -39,6 +39,9 @@ pangeo:
         enabled: false
   gateway:
     clusterManager:
+      image:
+        name: pangeo/base-notebook
+        tag: 2019.12.24
       clusterStartTimeout: 600
       workerStartTimeout: 600
       worker:
@@ -55,6 +58,7 @@ pangeo:
               value: "worker"
     extraConfig: |
       from dask_gateway_server.options import Options, Integer, Float, String
+
       def option_handler(options):
           if ":" not in options.image:
               raise ValueError("When specifying an image you must also provide a tag")
@@ -67,7 +71,7 @@ pangeo:
       c.DaskGateway.cluster_manager_options = Options(
           Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
           Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
-          String("image", default="daskgateway/dask-gateway:0.6.1", label="Image"),
+          String("image", default="pangeo/base-notebook:2019.12.24", label="Image"),
           handler=option_handler,
       )
 


### PR DESCRIPTION
On staging.hub.pangeo.io, I think we have a mismatch between the dask-gateway versions. I think the server is at 0.6.1, but the ClusterManager is pulling an older version. This may be causes the errors I'm seeing

```
dask-gateway-scheduler: error: unrecognized arguments: --adaptive-period 3.0 --idle-timeout 0.0
```

on `create_cluster()`.

We'll need a better strategy for pinning the version of dask-gateway in the worker / scheduler images via pangeo-stacks to the version used on the server (from helm I think). Not sure what the best strategy is yet.