### PR TITLE
Have default dask-gateway image match

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -58,6 +58,7 @@ pangeo:
                 operator: "Equal"
                 value: "worker"
       extraConfig: |
+        import os
         from dask_gateway_server.options import Options, Integer, Float, String
 
         def option_handler(options):
@@ -72,7 +73,7 @@ pangeo:
         c.DaskGateway.cluster_manager_options = Options(
             Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
             Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
-            String("image", default="pangeo/base-notebook:2019.12.24", label="Image"),
+            String("image", default=os.environ.get("JUPYTER_IMAGE_SPEC"), label="Image"),
             handler=option_handler,
         )
 


### PR DESCRIPTION
This sets the default image for dask-gateway to `JUPYTER_IMAGE_SPEC`, which is probably a good default.