### PR TITLE
Default image 2

### DIFF
--- a/deployments/dev/image/binder/dask_config.yaml
+++ b/deployments/dev/image/binder/dask_config.yaml
@@ -49,3 +49,5 @@ gateway:
   proxy-address: tls://35.225.202.35:8786
   auth:
     type: jupyterhub
+  cluster:
+    image: ${JUPYTER_IMAGE_SPEC}

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -58,7 +58,6 @@ pangeo:
                 operator: "Equal"
                 value: "worker"
       extraConfig: |
-        import os
         from dask_gateway_server.options import Options, Integer, Float, String
 
         def option_handler(options):
@@ -73,7 +72,7 @@ pangeo:
         c.DaskGateway.cluster_manager_options = Options(
             Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
             Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
-            String("image", default=os.environ.get("JUPYTER_IMAGE_SPEC"), label="Image"),
+            String("image", default="pangeo/base-notebook:2019.12.24", label="Image"),
             handler=option_handler,
         )
 


### PR DESCRIPTION
Reverts https://github.com/pangeo-data/pangeo-cloud-federation/pull/506 and (hopefully) provides a working alternative.

The goal is to use `JUPYTER_IMAGE_SPEC` as the default image. That env var isn't available on the dask-gateway server, only on the client. So we override the version from the server with a local default in the typical Dask config file (which is on the client and has `JUPYTER_IMAGE_SPEC`).