### PR TITLE
Set gateway-enforced resource limits

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -78,8 +78,10 @@ pangeo:
               handler=option_handler,
           )
 
-        c.UserLimits.max_cores = 100
-        c.UesrLimits.max_memory = "400 GB"
+        userLimts:
+          c.UserLimits.max_cores = 100
+          c.UserLimits.max_memory = "400 GB"
+          c.UserLimits.max_clusters = 1
 
 homeDirectories:
   nfs:

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -76,6 +76,9 @@ pangeo:
             handler=option_handler,
         )
 
+        c.UserLimits.max_cores = 100
+        c.UesrLimits.max_memory = "400 GB"
+
 homeDirectories:
   nfs:
     enabled: false


### PR DESCRIPTION
This limits the amount of cores and memory that users can request. Requesting more than that will (I believe) raise an exception.

@jhamman @rabernat do you have suggestions for what reasonable values would be here?