### PR TITLE
fixup userLimits config

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -78,7 +78,7 @@ pangeo:
               handler=option_handler,
           )
 
-        userLimts:
+        userLimts: |
           c.UserLimits.max_cores = 100
           c.UserLimits.max_memory = "400 GB"
           c.UserLimits.max_clusters = 1


### PR DESCRIPTION
We were generating a bad config.

Need to figure out a better testing strategy here. This would have been caught by

1. Rendering the dask_gatewey_config.py file (via helm somehow?)
2. Asserting that the config was a valid python file.