### PR TITLE
Secure gateway with TLS

### DIFF
--- a/deployments/dev/image/binder/dask_config.yaml
+++ b/deployments/dev/image/binder/dask_config.yaml
@@ -45,7 +45,7 @@ labextension:
     kwargs: {}
 
 gateway:
-  address: http://34.68.195.134
+  address: https://staging.hub.pangeo.io/services/dask-gateway/
   proxy-address: tls://35.225.202.35:8786
   auth:
     type: jupyterhub

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -83,6 +83,11 @@ pangeo:
           c.UserLimits.max_memory = "400 G"
           c.UserLimits.max_clusters = 1
 
+        tlsURL: |
+          if isinstance(c.DaskGateway.public_connect_url, str):
+              c.DaskGateway.public_connect_url += "/services/dask-gateway"
+
+
 homeDirectories:
   nfs:
     enabled: false


### PR DESCRIPTION
Thanks to @jcrist for the suggestion. IIUC, we're piggy backing on jupyterhub's TLS.

We'll need to apply the change to the `dask_confg.yaml` to each deployment.