### PR TITLE
Ensure scheduler, worker pods on correct node pool

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -51,12 +51,15 @@ pangeo:
               - key: "k8s.dask.org_dedicated"
                 operator: "Equal"
                 value: "worker"
-        scheduler:
-          extraPodConfig:
-            tolerations:
-              - key: "k8s.dask.org_dedicated"
-                operator: "Equal"
-                value: "worker"
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: "k8s.dask.org_dedicated"
+                        operator: "Equal"
+                        value: "worker"
+
       extraConfig:
         # Use the mapping form, to support merging multiple values.yaml
         optionHandler: |
@@ -91,4 +94,3 @@ pangeo:
 homeDirectories:
   nfs:
     enabled: false
-  


### PR DESCRIPTION
Two changes here:

1. Ensure that worker pods are on preemptible nodes.
   This requires that the k8s cluster have nodes with the
   `k8s.dask.org_dedicated:worker` label. Otherwise workers won't start.
   Do we want this in the base config used for all our hubs?
2. Ensure that scheduler pods are *not* on preemptible nodes.

Right now, we can have scheduler pods end up in the preemptible nodes in
the dask pool

```
$ kubectl describe pod -n dev-staging dask-gateway-tomaugspurger-scheduler-df5cb0c595ca4c80adc12a82c84e7150 | grep pool
Node:         gke-dev-pangeo-io-cluster-dask-pool-f89fa71c-rh7b/10.128.0.82
  Normal  Scheduled  3m4s  default-scheduler                                           Successfully assigned dev-staging/dask-gateway-tomaugspurger-scheduler-df5cb0c595ca4c80adc12a82c84e7150 to gke-dev-pangeo-io-cluster-dask-pool-f89fa71c-rh7b
  ...
```

By removing the toleration, they won't end up there. I think this means
they'll always end up in the `core-pool`, which is currently not set up
to autoscale. We'll need to adjust that before merging this. @jhamman 
does putting schedulers in the core-pool sound OK? If so, is it OK to autoscale it, or should we set up a dedicated `dask-scheduler` that's not preemptible?