### PR TITLE
Bump xarray version

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - retrying==1.3.3
   - unyt==2.6.0
   - utide==0.2.5
+  - xarray>=0.15
   - xlrd==1.2.0
   - xgcm==0.3.0
   - nbdime==1.1.0


### PR DESCRIPTION
I experienced problems with a computation due to a bug that was recently solved in xarray (https://github.com/pydata/xarray/issues/3574#event-2970550094). This PR adds the most recent release of xarray