### PR TITLE
awscli fix for aws hubs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-git+https://github.com/yuvipanda/hubploy@1767689c5277400a473b9f239a851f75051d8240
+git+https://github.com/yuvipanda/hubploy@a02fb01bbc4a698b2cc85f9677e9881dac8d438a
 jupyter-repo2docker>=0.10.0
 pygithub
-awscli
 azure-cli


### PR DESCRIPTION
should fix failing staging build from https://github.com/pangeo-data/pangeo-cloud-federation/pull/467

now that aws cli command fixed within hubploy https://github.com/yuvipanda/hubploy/pull/52 