### PR TITLE
Adding cmip6_preprocessing

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - xgcm==0.3.0
   - nbdime==1.1.0
   - xlayers==0.2
+  - cmip6_preprocessing==0.1.1
   - pip
   - pip:
     - git+https://github.com/intake/filesystem_spec.git@master
@@ -30,4 +31,3 @@ dependencies:
     - git+https://github.com/NCAR/intake-esm.git
     - git+https://github.com/MITgcm/xmitgcm.git
     - git+https://github.com/xgcm/fastjmd95.git
-    - cmip6_preprocessing

--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -30,3 +30,4 @@ dependencies:
     - git+https://github.com/NCAR/intake-esm.git
     - git+https://github.com/MITgcm/xmitgcm.git
     - git+https://github.com/xgcm/fastjmd95.git
+    - cmip6_preprocessing


### PR DESCRIPTION
I just released [cmip6_preprocessing](https://github.com/jbusecke/cmip6_preprocessing) to pypi and would love to add it to the ocean.pangeo.io environment. 

I think this is a useful package for many people working on the CMIP6 stack.