### PR TITLE
added dynamic ip whitelist to aws-west2 deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,11 +240,24 @@ jobs:
       #     command: |
       #       hubploy deploy nasa pangeo-deploy ${CIRCLE_BRANCH}
 
+      # sleep 60 for now, but better to poll for readiness https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+      - run:
+          name: Add Runner IP to EKS Kubernetes API Whitelist
+          command: |
+            RUNNERIP=`curl --silent https://checkip.amazonaws.com`
+            aws --version
+            aws eks update-cluster-config --name pangeo --resources-vpc-config publicAccessCidrs=$RUNNERIP/32 > /dev/null
+            sleep 60
       - run:
           name: Deploy aws-uswest2.pangeo.io
           when: always
           command: |
             hubploy deploy icesat2 pangeo-deploy ${CIRCLE_BRANCH}
+      - run:
+          name: Revert to Original EKS IP Whitelist
+          when: always
+          command: |
+            aws eks update-cluster-config --name pangeo --resources-vpc-config publicAccessCidrs="${AWS_IP_WHITELIST }" > /dev/null
 
       - run:
           name: Deploy ooi.pangeo.io


### PR DESCRIPTION
@salvis2 and I worked on temporarily registering circleCI runner IP in EKS kubernetes API whitelist as described in this issue https://github.com/yuvipanda/hubploy/issues/39 

This ensures that the EKS cluster does not have a publicly accessible API from any IP, only a select few. 

Could add this to other hubs later, or incorporate as an option in hubploy