### PR TITLE
Scheduler pool docs

### DIFF
--- a/docs/dev-pangeo-io-cluster-config.md
+++ b/docs/dev-pangeo-io-cluster-config.md
@@ -1,7 +1,7 @@
 dev-pangeo-io-cluster
 =====================
 
-This document summarizes the `dev-pangeo-io-cluster` configuration and will be useful for users when picking ideal pod specifications for Jupyter and Dask applications. It was last updated Tue May 14 2019.
+This document summarizes the `dev-pangeo-io-cluster` configuration and will be useful for users when picking ideal pod specifications for Jupyter and Dask applications. It was last updated March 23, 2020.
 
 
 ## Node-Pools
@@ -20,9 +20,12 @@ scheduler-pool      n1-highmem-16  100           1.15.9-gke.22
 ## Node-Pool Descriptions
 
 The node-pool descriptions for each node pool, including labels and taints, are listed below:
-<!-- for pool in core-pool temp-dask-pool dask-pool jupyter-pool; do echo $ gcloud container node-pools describe --cluster  dev-pangeo-io-cluster $pool; gcloud container node-pools describe --cluster  dev-pangeo-io-cluster $pool; echo " "; done -->
+<!-- for pool in core-pool dask-pool jupyter-pool scheduler-pool; do echo $ gcloud container node-pools describe --cluster  dev-pangeo-io-cluster $pool; gcloud container node-pools describe --cluster  dev-pangeo-io-cluster $pool; echo " "; done -->
 ```bash
 $ gcloud container node-pools describe --cluster dev-pangeo-io-cluster core-pool
+autoscaling:
+  enabled: true
+  maxNodeCount: 100
 config:
   diskSizeGb: 100
   diskType: pd-standard
@@ -41,52 +44,23 @@ config:
 initialNodeCount: 3
 instanceGroupUrls:
 - https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-cluster-core-pool-55304abd-grp
+locations:
+- us-central1-b
 management:
   autoRepair: true
+  autoUpgrade: true
 maxPodsConstraint:
   maxPodsPerNode: '110'
 name: core-pool
 podIpv4CidrSize: 24
 selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/core-pool
 status: RUNNING
-version: 1.11.8-gke.6
-
-$ gcloud container node-pools describe --cluster dev-pangeo-io-cluster temp-dask-pool
-autoscaling:
-  enabled: true
-  maxNodeCount: 100
-config:
-  diskSizeGb: 100
-  diskType: pd-standard
-  imageType: COS
-  labels:
-    k8s.dask.org/node-purpose: worker
-  machineType: n1-highmem-4
-  oauthScopes:
-  - https://www.googleapis.com/auth/devstorage.read_only
-  - https://www.googleapis.com/auth/logging.write
-  - https://www.googleapis.com/auth/monitoring
-  - https://www.googleapis.com/auth/service.management.readonly
-  - https://www.googleapis.com/auth/servicecontrol
-  - https://www.googleapis.com/auth/trace.append
-  preemptible: true
-  serviceAccount: default
-instanceGroupUrls:
-- https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-clus-temp-dask-pool-8bacb14c-grp
-management:
-  autoRepair: true
-maxPodsConstraint:
-  maxPodsPerNode: '110'
-name: temp-dask-pool
-podIpv4CidrSize: 24
-selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/temp-dask-pool
-status: RUNNING
-version: 1.11.8-gke.6
+version: 1.15.9-gke.22
 
 $ gcloud container node-pools describe --cluster dev-pangeo-io-cluster dask-pool
 autoscaling:
   enabled: true
-  maxNodeCount: 10
+  maxNodeCount: 300
 config:
   diskSizeGb: 100
   diskType: pd-ssd
@@ -109,20 +83,23 @@ config:
     value: worker
 instanceGroupUrls:
 - https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-cluster-dask-pool-f89fa71c-grp
+locations:
+- us-central1-b
 management:
   autoRepair: true
+  autoUpgrade: true
 maxPodsConstraint:
   maxPodsPerNode: '110'
 name: dask-pool
 podIpv4CidrSize: 24
 selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/dask-pool
 status: RUNNING
-version: 1.11.8-gke.6
+version: 1.15.9-gke.22
 
 $ gcloud container node-pools describe --cluster dev-pangeo-io-cluster jupyter-pool
 autoscaling:
   enabled: true
-  maxNodeCount: 10
+  maxNodeCount: 30
 config:
   diskSizeGb: 100
   diskType: pd-ssd
@@ -144,6 +121,8 @@ config:
     value: user
 instanceGroupUrls:
 - https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-cluste-jupyter-pool-0752f5af-grp
+locations:
+- us-central1-b
 management:
   autoRepair: true
   autoUpgrade: true
@@ -153,7 +132,47 @@ name: jupyter-pool
 podIpv4CidrSize: 24
 selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/jupyter-pool
 status: RUNNING
-version: 1.11.8-gke.6
+version: 1.15.9-gke.22
+
+$ gcloud container node-pools describe --cluster dev-pangeo-io-cluster scheduler-pool
+autoscaling:
+  enabled: true
+  maxNodeCount: 50
+config:
+  diskSizeGb: 100
+  diskType: pd-standard
+  imageType: COS
+  machineType: n1-highmem-16
+  metadata:
+    disable-legacy-endpoints: 'true'
+  oauthScopes:
+  - https://www.googleapis.com/auth/devstorage.read_only
+  - https://www.googleapis.com/auth/logging.write
+  - https://www.googleapis.com/auth/monitoring
+  - https://www.googleapis.com/auth/service.management.readonly
+  - https://www.googleapis.com/auth/servicecontrol
+  - https://www.googleapis.com/auth/trace.append
+  serviceAccount: default
+  shieldedInstanceConfig:
+    enableIntegrityMonitoring: true
+  taints:
+  - effect: NO_SCHEDULE
+    key: k8s.dask.org/dedicated
+    value: scheduler
+instanceGroupUrls:
+- https://www.googleapis.com/compute/v1/projects/pangeo-181919/zones/us-central1-b/instanceGroupManagers/gke-dev-pangeo-io-clus-scheduler-pool-00b995a0-grp
+locations:
+- us-central1-b
+management:
+  autoRepair: true
+  autoUpgrade: true
+maxPodsConstraint:
+  maxPodsPerNode: '110'
+name: scheduler-pool
+podIpv4CidrSize: 24
+selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/scheduler-pool
+status: RUNNING
+version: 1.15.9-gke.22
 ```
 
 ## Scheduler Pool

--- a/docs/dev-pangeo-io-cluster-config.md
+++ b/docs/dev-pangeo-io-cluster-config.md
@@ -8,11 +8,13 @@ This document summarizes the `dev-pangeo-io-cluster` configuration and will be u
 ```bash
 $ gcloud container node-pools list --cluster dev-pangeo-io-cluster
 
-NAME            MACHINE_TYPE   DISK_SIZE_GB  NODE_VERSION
-core-pool       n1-standard-2  100           1.11.8-gke.6
-temp-dask-pool  n1-highmem-4   100           1.11.8-gke.6
-dask-pool       n1-highmem-4   100           1.11.8-gke.6
-jupyter-pool    n1-highmem-16  100           1.11.8-gke.6
+NAME                MACHINE_TYPE   DISK_SIZE_GB  NODE_VERSION
+core-pool           n1-standard-2  100           1.15.9-gke.22
+dask-pool           n1-highmem-4   100           1.15.9-gke.22
+jupyter-pool        n1-highmem-16  100           1.15.9-gke.22
+jupyter-pool-small  n1-highmem-2   100           1.15.9-gke.22
+jupyter-gpu-pool    n1-standard-4  100           1.15.9-gke.22
+scheduler-pool      n1-highmem-16  100           1.15.9-gke.22
 ```
 
 ## Node-Pool Descriptions
@@ -152,4 +154,21 @@ podIpv4CidrSize: 24
 selfLink: https://container.googleapis.com/v1/projects/pangeo-181919/zones/us-central1-b/clusters/dev-pangeo-io-cluster/nodePools/jupyter-pool
 status: RUNNING
 version: 1.11.8-gke.6
+```
+
+## Scheduler Pool
+
+A pool dedicated to schedulers was added in https://github.com/pangeo-data/pangeo-cloud-federation/pull/567.
+It was created with
+
+```
+gcloud container node-pools create scheduler-pool \
+    --cluster=dev-pangeo-io-cluster \
+    --num-nodes=0 \
+    --machine-type=n1-highmem-16 \
+    --zone=us-central1-b \
+    --enable-autoupgrade \
+    --enable-autorepair \
+    --enable-autoscaling --min-nodes=0 --max-nodes=50 \
+    --node-taints=k8s.dask.org/dedicated=scheduler:NoSchedule
 ```


### PR DESCRIPTION
@scottyhq I've added a pool dedicated for schedulers in https://github.com/pangeo-data/pangeo-cloud-federation/commit/2cbef8b08f3fdd54738b7847e3008be45c3cdc47 (autoscaling from 0 - 50 machines).

We'll need to update the configs to ensure that scheduler pods end up there. I'll do that in https://github.com/pangeo-data/pangeo-cloud-federation/pull/536 once everyone is ready?