### PR TITLE
scheduler public, full https gateway address

### DIFF
--- a/deployments/icesat2/config/prod.yaml
+++ b/deployments/icesat2/config/prod.yaml
@@ -8,8 +8,8 @@ pangeo:
           url: http://web-public-icesat2-prod-dask-gateway
     singleuser:
       extraEnv:
-        DASK_GATEWAY__ADDRESS: "http://web-public-icesat2-prod-dask-gateway/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-icesat2-prod-dask-gateway:8786"
+        DASK_GATEWAY__ADDRESS: "https://aws-uswest2.pangeo.io/services/dask-gateway"
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-icesat2-prod-dask-gateway:8786"
     proxy:
       https:
         hosts:

--- a/deployments/icesat2/config/staging.yaml
+++ b/deployments/icesat2/config/staging.yaml
@@ -16,8 +16,8 @@ pangeo:
           url: http://web-public-icesat2-staging-dask-gateway
     singleuser:
       extraEnv:
-        DASK_GATEWAY__ADDRESS: "http://web-public-icesat2-staging-dask-gateway/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-icesat2-staging-dask-gateway:8786"
+        DASK_GATEWAY__ADDRESS: "https://staging.aws-uswest2.pangeo.io/services/dask-gateway"
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-icesat2-staging-dask-gateway:8786"
     proxy:
       https:
         hosts:


### PR DESCRIPTION
@TomAugspurger - after a bit more testing the only way I'm able to get the dask-labextension to work is if I specify the full https address for the gateway (maybe it's different somehow from GKE). 
```
    singleuser:
      extraEnv:
        DASK_GATEWAY__ADDRESS: "https://staging.aws-uswest2.pangeo.io/services/dask-gateway"
```

using the pod name results in a `DNS_PROBE_FINISHED_NXDOMAIN error trying to access the dashboard:
```
DASK_GATEWAY__ADDRESS: "http://web-public-icesat2-staging-dask-gateway/services/dask-gateway/"
```

