### PR TITLE
Cleanup dev-staging config

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -31,11 +31,10 @@ pangeo:
       memory:
         limit: 14G
         guarantee: 4G
+      extraEnv:
+        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+
     hub:
-      services:
-        dask-gateway:
-          # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: http://web-public-dev-staging-dask-gateway
       resources:
         requests:
           cpu: "0.25"

--- a/deployments/dev/config/staging.yaml
+++ b/deployments/dev/config/staging.yaml
@@ -16,3 +16,12 @@ pangeo:
     scheduling:
       userScheduler:
         enabled: false
+    singleuser:
+      extraEnv:
+        DASK_GATEWAY__ADDRESS: "https://staging.hub.pangeo.io/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-dev-staging-dask-gateway:8786"
+    hub:
+      services:
+        dask-gateway:
+          # This makes the gateway available at ${HUB_URL}/services/dask-gateway
+          url: "http://web-public-dev-staging-dask-gateway"

--- a/deployments/dev/image/binder/dask_config.yaml
+++ b/deployments/dev/image/binder/dask_config.yaml
@@ -43,12 +43,3 @@ labextension:
     class: KubeCluster
     args: []
     kwargs: {}
-
-gateway:
-  address: https://staging.hub.pangeo.io/services/dask-gateway/
-  proxy-address: tls://35.225.202.35:8786
-  auth:
-    type: jupyterhub
-  cluster:
-    options:
-      image: '{JUPYTER_IMAGE_SPEC}'


### PR DESCRIPTION
* Moves config to environment variables rather than dask_config.yaml
* Organizes a few common config values that apply everywhere, and a few deploy-specific config values