### PR TITLE
Dask-Gateway config for hydro-staging

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -31,8 +31,6 @@ pangeo:
       memory:
         limit: 14G
         guarantee: 4G
-      extraEnv:
-        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
 
     hub:
       resources:

--- a/deployments/dev/image/binder/environment.yml
+++ b/deployments/dev/image/binder/environment.yml
@@ -2,4 +2,4 @@ name: dev
 channels:
   - conda-forge
 dependencies:
-  - dask-gateway
+  - pangeo-notebook==0.0.2

--- a/deployments/dev/image/binder/environment.yml
+++ b/deployments/dev/image/binder/environment.yml
@@ -2,4 +2,4 @@ name: dev
 channels:
   - conda-forge
 dependencies:
-  - pangeo-notebook==0.0.2
+  - dask-gateway

--- a/deployments/hydro/config/staging.yaml
+++ b/deployments/hydro/config/staging.yaml
@@ -16,3 +16,12 @@ pangeo:
     scheduling:
       userScheduler:
         enabled: false
+    singleuser:
+      extraEnv:
+        DASK_GATEWAY__ADDRESS: "https://staging.hydro.pangeo.io/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-hydro-staging-dask-gateway:8786"
+    hub:
+      services:
+        dask-gateway:
+          # This makes the gateway available at ${HUB_URL}/services/dask-gateway
+          url: "http://web-public-hydro-staging-dask-gateway"

--- a/deployments/hydro/image/binder/environment.yml
+++ b/deployments/hydro/image/binder/environment.yml
@@ -2,11 +2,12 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - pangeo-notebook==0.0.2
   - conda>=4.6.8
   - python=3.7
   - numpy
   - matplotlib
+  - dask
+  - dask-gateway
   - xarray>0.10.9
   - ipyleaflet
   - seaborn
@@ -19,3 +20,4 @@ dependencies:
   - pip:
     - git+https://github.com/arbennett/pysumma.git@706a69f1ff3a8e910ea574e133cd12a434290152
     - hs_restclient
+    - nbgitpuller

--- a/deployments/hydro/image/binder/environment.yml
+++ b/deployments/hydro/image/binder/environment.yml
@@ -2,11 +2,11 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
+  - pangeo-notebook==0.0.2
   - conda>=4.6.8
   - python=3.7
   - numpy
   - matplotlib
-  - dask
   - xarray>0.10.9
   - ipyleaflet
   - seaborn
@@ -19,4 +19,3 @@ dependencies:
   - pip:
     - git+https://github.com/arbennett/pysumma.git@706a69f1ff3a8e910ea574e133cd12a434290152
     - hs_restclient
-    - nbgitpuller

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -26,6 +26,10 @@ pangeo:
         limit: 4G
         guarantee: 2G
 
+      extraEnv:
+        # The default worker image matches the singleuser image.
+        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+
     prePuller:
       hook:
         enabled: false


### PR DESCRIPTION
And two bonus changes

1. https://github.com/pangeo-data/pangeo-cloud-federation/commit/03727869fec93c8a1d366a484f7b0978eca0105a: Move the image config all the way to `values.yaml`
2. https://github.com/pangeo-data/pangeo-cloud-federation/commit/e4272638c17d7084136060b6eab5d1cb79d23961: Use pangeo-notebook in the dev environment.yaml