### PR TITLE
Fix dask-gateway server image

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -43,9 +43,6 @@ pangeo:
         enabled: false
   dask-gateway:
     gateway:
-      image:
-        name: pangeo/base-notebook
-        tag: latest
         # TODO: ClusterManger replacment
         # clusterStartTimeout: 600
         # workerStartTimeout: 1200


### PR DESCRIPTION
I think this might fix things. Debugging tip: After the `helm` deploy times out

```
$ kubectl -n dev-staging get events --sort-by='{.lastTimestamp}'
4m15s       Normal    Pulled                   pod/api-dev-staging-dask-gateway-7476d6cb59-rjp96               Container image "pangeo/base-notebook:latest" already present on machine
4m15s       Normal    Created                  pod/api-dev-staging-dask-gateway-7476d6cb59-rjp96               Created container gateway
4m14s       Warning   Failed                   pod/api-dev-staging-dask-gateway-7476d6cb59-rjp96               Error: failed to start container "gateway": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"dask-gateway-server\": executable file not found in $PATH": unknown
78s         Normal    NoPods                   poddisruptionbudget/user-scheduler                              No matching pods found
40s         Warning   BackOff                  pod/api-dev-staging-dask-gateway-7476d6cb59-rjp96               Back-off restarting failed container
```

I'm not sure if it was local debugging or the previous failed deploy that messed things up, but I had to clean up a bunch of stuff

```
kubectl -n dev-staging delete serviceaccount controller-dev-staging-dask-gateway
kubectl -n dev-staging delete serviceaccount api-dev-staging-dask-gateway
kubectl -n dev-staging delete serviceaccount traefik-dev-staging-dask-gateway
kubectl -n dev-staging delete secret api-dev-staging-dask-gateway
kubectl -n dev-staging delete configmap controller-dev-staging-dask-gateway
kubectl -n dev-staging delete configmap api-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrole controller-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrole api-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrole traefik-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrolebinding controller-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrolebinding api-dev-staging-dask-gateway
kubectl -n dev-staging delete clusterrolebinding traefik-dev-staging-dask-gateway
kubectl -n dev-staging delete service api-dev-staging-dask-gateway
kubectl -n dev-staging delete service traefik-dev-staging-dask-gateway
kubectl -n dev-staging delete deployment controller-dev-staging-dask-gateway
kubectl -n dev-staging delete deployment api-dev-staging-dask-gateway
kubectl -n dev-staging delete deployment traefik-dev-staging-dask-gateway
kubectl -n dev-staging delete ingressroute api-dev-staging-dask-gateway
kubectl -n dev-staging delete middleware clusters-prefix-dev-staging-dask-gateway
kubectl -n dev-staging delete middleware api-prefix-dev-staging-dask-gateway
```

Not sure if that'll be needed for the others.