### PR TITLE
Set jupyterhub auth

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -42,6 +42,8 @@ pangeo:
       userPlaceholder:
         enabled: false
   dask-gateway:
+    auth:
+      type: jupyterhub
     gateway:
         # TODO: ClusterManger replacment
         # clusterStartTimeout: 600


### PR DESCRIPTION
Unsure why this is necessary, given that we set this in the pangeo helm
chart. Perhaps since we override the token in the secret files,
which is a subkey?