### PR TITLE
Set idle timeout

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -61,7 +61,10 @@ pangeo:
         #   c.UserLimits.max_cores = 100
         #   c.UserLimits.max_memory = "400 G"
         #   c.UserLimits.max_clusters = 1
-
+      extraConfig:
+        idle: |
+          # timeout after 30 minutes of inactivity
+          c.KubeClusterConfig.idle_timeout = 1800
 
 homeDirectories:
   nfs:


### PR DESCRIPTION
This will shutdown the Dask cluster if there's no activity for 30 minutes.

I apparently forgot to do this for the hubs after doing it to the binders in https://github.com/pangeo-data/pangeo-binder/pull/148.