### PR TITLE
draft maintenance announcements

### DIFF
--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -68,7 +68,8 @@ pangeo:
           c.JupyterHub.template_vars = {
             'pangeo_hub_title': 'hub.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for geoscience research',
-            'pangeo_welcome': """Welcome to hub.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>."""
+            'pangeo_welcome': """Welcome to hub.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
+            'announcement': 'hub.pangeo.io is being shutdown. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
           }
 
       extraVolumes:

--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -69,14 +69,14 @@ pangeo:
             'pangeo_hub_title': 'hub.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for geoscience research',
             'pangeo_welcome': """Welcome to hub.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
-            'announcement': 'hub.pangeo.io is being shutdown. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
+            'announcement': 'hub.pangeo.io is being decommissioned on Monday, June 22, 2020. Please see <a href="https://discourse.pangeo.io/t/migration-of-ocean-pangeo-io-user-accounts/644">Discourse</a> for more information.'
           }
 
       extraVolumes:
         - name: custom-templates
           gitRepo:
             repository: "https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates.git"
-            revision: "0c799bb2f880c8b516dcf90e2a90328078d60c25"
+            revision: "39962614b3df4ca86efb29712f7e67c51308d25b"
       extraVolumeMounts:
         - mountPath: /usr/local/share/jupyterhub/custom_templates
           name: custom-templates

--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -101,7 +101,8 @@ pangeo:
           c.JupyterHub.template_vars = {
             'pangeo_hub_title': 'hydro.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for hydrologic research',
-            'pangeo_welcome': """Welcome to hydro.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>."""
+            'pangeo_welcome': """Welcome to hydro.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
+            'announcement': 'hydro.pangeo.io is being shutdown. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
           }
 
       extraVolumes:

--- a/deployments/hydro/config/common.yaml
+++ b/deployments/hydro/config/common.yaml
@@ -102,14 +102,14 @@ pangeo:
             'pangeo_hub_title': 'hydro.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for hydrologic research',
             'pangeo_welcome': """Welcome to hydro.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
-            'announcement': 'hydro.pangeo.io is being shutdown. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
+            'announcement': 'hydro.pangeo.io is being decommissioned on Monday, June 22, 2020. Please see <a href="https://discourse.pangeo.io/t/migration-of-ocean-pangeo-io-user-accounts/644">Discourse</a> for more information.'
           }
 
       extraVolumes:
         - name: custom-templates
           gitRepo:
             repository: "https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates.git"
-            revision: "0c799bb2f880c8b516dcf90e2a90328078d60c25"
+            revision: "39962614b3df4ca86efb29712f7e67c51308d25b"
       extraVolumeMounts:
         - mountPath: /usr/local/share/jupyterhub/custom_templates
           name: custom-templates

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -73,7 +73,8 @@ pangeo:
           c.JupyterHub.template_vars = {
             'pangeo_hub_title': 'ocean.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for ocean, atmospheric, and climate research',
-            'pangeo_welcome': """Welcome to ocean.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>."""
+            'pangeo_welcome': """Welcome to ocean.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
+            'announcement': 'ocean.pangeo.io will be undergoing maintanence from June 18 through June 25. Active users of this JupyterHub must fill out <a> this </a> form to continue using this system. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
           }
 
       extraVolumes:

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -81,7 +81,7 @@ pangeo:
         - name: custom-templates
           gitRepo:
             repository: "https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates.git"
-            revision: "0c799bb2f880c8b516dcf90e2a90328078d60c25"
+            revision: "39962614b3df4ca86efb29712f7e67c51308d25b"
       extraVolumeMounts:
         - mountPath: /usr/local/share/jupyterhub/custom_templates
           name: custom-templates

--- a/deployments/ocean/config/common.yaml
+++ b/deployments/ocean/config/common.yaml
@@ -74,7 +74,7 @@ pangeo:
             'pangeo_hub_title': 'ocean.pangeo.io',
             'pangeo_hub_subtitle': 'a community hub for ocean, atmospheric, and climate research',
             'pangeo_welcome': """Welcome to ocean.pangeo.io. This hub lives in Google Cloud region <code>us-central1-b</code>. It is maintained by the <a href="http://pangeo.io">Pangeo project</a> and supported by a grant from the National Science Foundation (NSF award 1740648), which includes a direct award of cloud credits from Google Cloud. The hub's configuration is stored in the github repository <a href="https://github.com/pangeo-data/pangeo-cloud-federation/">https://github.com/pangeo-data/pangeo-cloud-federation/</a>. To provide feedback and report any technical problems, please use the <a href="https://github.com/pangeo-data/pangeo-cloud-federation//issues">github issue tracker</a>.""",
-            'announcement': 'ocean.pangeo.io will be undergoing maintanence from June 18 through June 25. Active users of this JupyterHub must fill out <a> this </a> form to continue using this system. Please see <a href="https://discourse.pangeo.io/">Discourse</a> for more information.'
+            'announcement': 'ocean.pangeo.io will be undergoing maintenance from June 22 through June 26. Active users of this JupyterHub must fill out <a href="https://forms.gle/je75vEPiHGkwfFVv8">this form</a> to continue using this system. Please see <a href="https://discourse.pangeo.io/t/migration-of-ocean-pangeo-io-user-accounts/644>Discourse</a> for more information.'
           }
 
       extraVolumes:


### PR DESCRIPTION
This get's the ball rolling for our announcements related to shutting down hub.pangeo.io, hydro.pangeo.io, and reconfiguring ocean.pangeo.io. 

TODO:
- [x] merge https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates/pull/6
- [x] update our custom configs to point to new custom templates (from PR above)
- [x] settle on announcement text and link to discourse.

cc @rabernat, @TomAugspurger 