### PR TITLE
Add telemetery

### DIFF
--- a/deployments/gcp-uscentral1b/Makefile
+++ b/deployments/gcp-uscentral1b/Makefile
@@ -40,7 +40,7 @@ cluster:
 		--enable-autoupgrade --enable-autorepair --max-surge-upgrade=1 \
 		--machine-type=n1-standard-1 \
 		--enable-autoscaling --min-nodes=1 --max-nodes=2 \
-		--node-labels="hub.jupyter.org/nodepurpose=core" \
+		--node-labels="hub.jupyter.org/node-purpose=core" \
 		--enable-autoprovisioning --autoprovisioning-config-file autoprovisioning.json \
 		--enable-vertical-pod-autoscaling \
 		--workload-metadata=GKE_METADATA \

--- a/deployments/gcp-uscentral1b/Makefile
+++ b/deployments/gcp-uscentral1b/Makefile
@@ -85,3 +85,13 @@ serviceaccount:
 	  --overwrite --namespace $(NAMESPACE) \
 		pangeo \
 		iam.gke.io/gcp-service-account=pangeo@$(PROJECT).iam.gserviceaccount.com
+
+
+print-grafana-password:
+	@kubectl get secret -n $(NAMESPACE) gcp-uscentral1b-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo 
+
+forward-grafana:
+	kubectl port-forward -n $(NAMESPACE) `kubectl -n $(NAMESPACE) get pod -l 'app.kubernetes.io/name=grafana' -o name` 3000
+
+forward-prometheus:
+	kubectl port-forward -n $(NAMESPACE) `kubectl -n $(NAMESPACE) get pod -l 'app=prometheus,component=server' -o name` 9090

--- a/deployments/gcp-uscentral1b/Makefile
+++ b/deployments/gcp-uscentral1b/Makefile
@@ -1,5 +1,6 @@
 PROJECT?=pangeo-181919
 NAMESPACE?=staging
+RELEASE?=us-central1b-$(NAMESPACE)
 ZONE?=us-central1-b
 CLUSTER?=pangeo-uscentral1b
 
@@ -75,6 +76,15 @@ nfs:
 destroy-nfs:
 	echo "[Destroying NFS server: $(CLUSTER)]"
 	gcloud filestore instances delete $(CLUSTER) --zone=$(ZONE)
+
+
+pangeo:
+	helm upgrade --wait --install \
+		$(RELEASE) ../../pangeo-deploy \
+		--namespace=$(NAMESPACE) --version=0.1.0 \
+		-f ./config/common.yaml \
+		-f ./config/$(NAMESPACE).yaml \
+		-f ./secrets/$(NAMESPACE).yaml
 
 serviceaccount:
 	gcloud iam service-accounts add-iam-policy-binding \

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -144,6 +144,6 @@ grafana:
         - name: prometheus
           orgId: 1
           type: prometheus
-          url: http://gcp-uscentral1b-prometheus-server
+          url: http://us-central1b-staging-prometheus-server
           access: proxy
           isDefault: true

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -1,9 +1,6 @@
 pangeo:
   jupyterhub:
     scheduling:
-      userPods:
-        nodeAffinity:
-          matchNodePurpose: require
       corePods:
         nodeAffinity:
           matchNodePurpose: require
@@ -17,12 +14,12 @@ pangeo:
           volumeMounts:
           - name: home
             mountPath: /home/jovyan
-            subPath: "home/hub/{username}"
+            subPath: "uscentral1b/{username}"
       storage:
         type: static
         static:
           pvcName: home-nfs
-          subPath: "home/hub/{username}"
+          subPath: "uscentral1b/{username}"
       cloudMetadata:
         enabled: true
     hub:

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -5,6 +5,11 @@ pangeo:
         nodeAffinity:
           matchNodePurpose: require
     singleuser:
+      # XXX: Hubploy should handle the image stuff
+      image:
+        name: pangeo/pangeo-notebook
+        tag: b261b3e
+
       initContainers:
         - name: volume-mount-hack
           image: busybox

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -35,6 +35,8 @@ pangeo:
           prometheus.io/scrape: 'true'
           prometheus.io/path: '/hub/metrics'
       extraConfig:
+        administrators: |
+          c.Authenticator.admin_users = ["TomAugspurger"]
         image_pulls: |
           c.KubeSpawner.start_timeout = 60 * 10  # 10-minute timeout for large image pulls
         profile_list: |

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -135,3 +135,15 @@ homeDirectories:
     # Output from `gcloud filestore instances describe pangeo-uscentral1b --zone=us-central1-b`
     serverIP: 10.126.142.50
     serverName: home
+
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: prometheus
+          orgId: 1
+          type: prometheus
+          url: http://gcp-uscentral1b-prometheus-server
+          access: proxy
+          isDefault: true

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -33,6 +33,10 @@ pangeo:
         limits:
           cpu: "1.25"
           memory: 1Gi
+      service:
+        annotations:
+          prometheus.io/scrape: 'true'
+          prometheus.io/path: '/hub/metrics'
       extraConfig:
         image_pulls: |
           c.KubeSpawner.start_timeout = 60 * 10  # 10-minute timeout for large image pulls
@@ -89,6 +93,40 @@ pangeo:
         - mountPath: /usr/local/share/jupyterhub/static/extra-assets
           name: custom-templates
           subPath: "pangeo-custom-jupyterhub-templates/extra-assets"
+
+  dask-gateway:
+    gateway:
+      extraConfig:
+        optionHandler: |
+          from dask_gateway_server.options import Options, Integer, Float, String
+          def cluster_options(user):
+             def option_handler(options):
+                 if ":" not in options.image:
+                     raise ValueError("When specifying an image you must also provide a tag")
+                 extra_annotations = {
+                     "hub.jupyter.org/username": user.name,
+                     "prometheus.io/scrape": "true"
+                 }
+                 extra_labels = {
+                     "hub.jupyter.org/username": user.name,
+                 }
+                 return {
+                     "worker_cores_limit": options.worker_cores,
+                     "worker_cores": min(options.worker_cores / 2, 1),
+                     "worker_memory": "%fG" % options.worker_memory,
+                     "image": options.image,
+                     "scheduler_extra_pod_annotations": extra_annotations,
+                     "worker_extra_pod_annotations": extra_annotations,
+                     "scheduler_extra_pod_labels": extra_labels,
+                     "worker_extra_pod_labels": extra_labels,
+                 }
+             return Options(
+                 Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
+                 Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
+                 String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+                 handler=option_handler,
+             )
+          c.Backend.cluster_options = cluster_options
 
 homeDirectories:
   nfs:

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -25,3 +25,15 @@ pangeo:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
           url: "http://traefik-ocean-staging-dask-gateway.ocean-staging"
+
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: prometheus
+          orgId: 1
+          type: prometheus
+          url: http://gcp-uscentral1b-prometheus-server
+          access: proxy
+          isDefault: true

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -22,8 +22,9 @@ pangeo:
         enabled: false
     singleuser:
       extraEnv:
-        DASK_GATEWAY__ADDRESS: "https://staging.ocean.pangeo.io/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-ocean-staging-dask-gateway.ocean-staging:80"
+        # TODO: DNS
+        DASK_GATEWAY__ADDRESS: "https://34.69.173.244/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-us-central1b-staging-dask-gateway.staging:80"
     hub:
       services:
         dask-gateway:

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -13,6 +13,10 @@ pangeo:
         requests:
           cpu: "0.1"
           memory: 0.25Gi
+        limits:
+          cpu: "0.1"
+          memory: 0.25Gi
+
     scheduling:
       userScheduler:
         enabled: false

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -16,6 +16,10 @@ pangeo:
         limits:
           cpu: "0.1"
           memory: 0.25Gi
+      services:
+        dask-gateway:
+          # This makes the gateway available at ${HUB_URL}/services/dask-gateway
+          url: "http://traefik-us-central1b-staging-dask-gateway.staging"
 
     scheduling:
       userScheduler:
@@ -25,8 +29,3 @@ pangeo:
         # TODO: DNS
         DASK_GATEWAY__ADDRESS: "http://34.69.173.244/services/dask-gateway/"
         DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-us-central1b-staging-dask-gateway.staging:80"
-    hub:
-      services:
-        dask-gateway:
-          # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: "http://traefik-us-central1b-staging-dask-gateway.staging"

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -25,15 +25,3 @@ pangeo:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
           url: "http://traefik-ocean-staging-dask-gateway.ocean-staging"
-
-grafana:
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: prometheus
-          orgId: 1
-          type: prometheus
-          url: http://gcp-uscentral1b-prometheus-server
-          access: proxy
-          isDefault: true

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -23,10 +23,10 @@ pangeo:
     singleuser:
       extraEnv:
         # TODO: DNS
-        DASK_GATEWAY__ADDRESS: "https://34.69.173.244/services/dask-gateway/"
+        DASK_GATEWAY__ADDRESS: "http://34.69.173.244/services/dask-gateway/"
         DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-us-central1b-staging-dask-gateway.staging:80"
     hub:
       services:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: "http://traefik-ocean-staging-dask-gateway.ocean-staging"
+          url: "http://traefik-us-central1b-staging-dask-gateway.staging"

--- a/pangeo-deploy/Chart.yaml
+++ b/pangeo-deploy/Chart.yaml
@@ -10,3 +10,9 @@ dependencies:
     import-values:
       - child: rbac
         parent: rbac
+  - name: prometheus
+    version: 11.6.0
+    repository: https://kubernetes-charts.storage.googleapis.com
+  - name: grafana
+    version: 5.3.0
+    repository: https://kubernetes-charts.storage.googleapis.com

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -90,3 +90,7 @@ pangeo:
 homeDirectories:
   nfs:
     enabled: false
+
+grafana:
+  ingress:
+    enabled: true


### PR DESCRIPTION
- Adds prometheus and grafana as chart dependencies (affects all hubs)
- Adds default prometheus datasource to grafana (just gcp so far)
- Tell prometheus to scrape a few endpoints for jupyterhub, dask (just
  gcp so far)

TODO (later)

- [ ] make charts, export, and ensure they're imported by default.
- [ ] Hook up grafana to some kind of auth (decide what is public)

cc @jhamman