### PR TITLE
limit port scraping

### DIFF
--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -109,7 +109,8 @@ pangeo:
                      raise ValueError("When specifying an image you must also provide a tag")
                  extra_annotations = {
                      "hub.jupyter.org/username": user.name,
-                     "prometheus.io/scrape": "true"
+                     "prometheus.io/scrape": "true",
+                     "prometheus.io/port": "8787",
                  }
                  extra_labels = {
                      "hub.jupyter.org/username": user.name,


### PR DESCRIPTION
By default, prometheus scrapes all the ports started by a pod. We only want port 8787, not the scheduler itself or the dask-gateway API ports.

We won't get worker statistics till https://github.com/dask/dask-gateway/pull/282 is merged & deployed.