### PR TITLE
Add lifecycle.json, bump to 7 days

### DIFF
--- a/deployments/gcp-uscentral1b/Makefile
+++ b/deployments/gcp-uscentral1b/Makefile
@@ -87,6 +87,7 @@ pangeo:
 		-f ./secrets/$(NAMESPACE).yaml
 
 serviceaccount:
+	# Assumes the GSA `pangeo` exists. Run `make google-service-account` if not.
 	gcloud iam service-accounts add-iam-policy-binding \
 		--role roles/iam.workloadIdentityUser \
 		--member "serviceAccount:$(PROJECT).svc.id.goog[$(NAMESPACE)/pangeo]" \
@@ -95,6 +96,9 @@ serviceaccount:
 	  --overwrite --namespace $(NAMESPACE) \
 		pangeo \
 		iam.gke.io/gcp-service-account=pangeo@$(PROJECT).iam.gserviceaccount.com
+
+scratch:
+	gsutil lifecycle set lifecycle.json gs://pangeo-scratch
 
 
 print-grafana-password:
@@ -105,3 +109,6 @@ forward-grafana:
 
 forward-prometheus:
 	kubectl port-forward -n $(NAMESPACE) `kubectl -n $(NAMESPACE) get pod -l 'app=prometheus,component=server' -o name` 9090
+
+google-service-account:
+	gcloud iam service-accounts create pangeo

--- a/deployments/gcp-uscentral1b/lifecycle.json
+++ b/deployments/gcp-uscentral1b/lifecycle.json
@@ -1,0 +1,15 @@
+{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": {
+          "type": "Delete"
+        },
+        "condition": {
+          "age": 7,
+          "isLive": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
https://github.com/pangeo-data/pangeo/pull/780#discussion_r447202066

This is a one-time thing, doesn't interact with Kubernetes aside from running `make service account` to like the service accounts between GCP & Kubernetes.