### PR TITLE
Fixups

### DIFF
--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -35,10 +35,6 @@ pangeo:
         limits:
           cpu: "1.25"
           memory: 1Gi
-      service:
-        annotations:
-          prometheus.io/scrape: 'true'
-          prometheus.io/path: '/hub/metrics'
       extraConfig:
         administrators: |
           c.Authenticator.admin_users = ["TomAugspurger"]

--- a/deployments/gcp-uscentral1b/config/prod.yaml
+++ b/deployments/gcp-uscentral1b/config/prod.yaml
@@ -13,6 +13,12 @@ pangeo:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
           url: "http://traefik-us-central1b-prod-dask-gateway.prod"
+      service:
+        # Just in prod to avoid possible port contention.
+        annotations:
+          prometheus.io/scrape: 'true'
+          prometheus.io/path: '/hub/metrics'
+
     singleuser:
       extraEnv:
         # TODO: DNS


### PR DESCRIPTION
Right now deployments are failing when prometheus pods are stuck in the Pending state. They're requesting a specific port, but the port is already taken (I assume by another node-exporter?) But we shouldn't ever need more than one node-exporter per node, so I don't know why they're coming up in the first place.

Anyway, I manually deleted the DaemonSets keeping these ports alive and deleted the failed deployment.

Oh, and I moved the metrics to just prod in the hope that this avoids the issue again, but I'm not confident that actually was the cause.