### PR TITLE
update namespaces

### DIFF
--- a/deployments/gcp-uscentral1b/config/prod.yaml
+++ b/deployments/gcp-uscentral1b/config/prod.yaml
@@ -12,7 +12,7 @@ pangeo:
       services:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: "http://traefik-us-central1b-prod-dask-gateway.prod"
+          url: "http://traefik-gcp-uscentral1b-prod-dask-gateway.gcp-uscentral1b-prod"
       service:
         # Just in prod to avoid possible port contention.
         annotations:
@@ -22,5 +22,5 @@ pangeo:
     singleuser:
       extraEnv:
         # TODO: DNS
-        DASK_GATEWAY__ADDRESS: "https://prod.us-central1-b.gcp.pangeo.io/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-us-central1b-prod-dask-gateway.prod:80"
+        DASK_GATEWAY__ADDRESS: "https://gcp-uscentral1b-prod.us-central1-b.gcp.pangeo.io/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-gcp-uscentral1b-prod-dask-gateway.gcp-uscentral1b-prod:80"

--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -19,13 +19,12 @@ pangeo:
       services:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: "http://traefik-us-central1b-staging-dask-gateway.staging"
+          url: "http://traefik-gcp-uscentral1b-staging-dask-gateway.gcp-uscentral1b-staging"
 
     scheduling:
       userScheduler:
         enabled: false
     singleuser:
       extraEnv:
-        # TODO: DNS
-        DASK_GATEWAY__ADDRESS: "https://staging.us-central1-b.gcp.pangeo.io/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-us-central1b-staging-dask-gateway.staging:80"
+        DASK_GATEWAY__ADDRESS: "https://gcp-uscentral1b-staging.us-central1-b.gcp.pangeo.io/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-gcp-uscentral1b-staging-dask-gateway.gcp-uscentral1b-staging:80"


### PR DESCRIPTION
These are what hub ploy is choosing.

I deployed this successfully after deleting the `staging` namespace.