### PR TITLE
Remove prometheus, grafana

### DIFF
--- a/pangeo-deploy/Chart.yaml
+++ b/pangeo-deploy/Chart.yaml
@@ -10,9 +10,3 @@ dependencies:
     import-values:
       - child: rbac
         parent: rbac
-  - name: prometheus
-    version: 11.6.0
-    repository: https://kubernetes-charts.storage.googleapis.com
-  - name: grafana
-    version: 5.3.0
-    repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Need to remove these for now. Pods in each namespace are trying to be scheduled on the same node, which gives conflicts with ports.

Ideally we have a separate `metrics` namespace. I'll explore that later.