### PR TITLE
auto-update the docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "deployments/gcp-uscentral1b/image/binder/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This adds a dependabot.yml file to automatically update the Dockerfile image when new versions are available for Pangeo-notebook. cc @rabernat. When an update is available the dependabot bot will make a pull request updating the tag.

@chiaral this will fix the issue you were seeing, and remove the need for a manual update step here.

@scottyhq is this something you would want for the icesat2 build as well?