### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "deployments/"
+    directory: "deployments/gcp-uscentral1b/image/binder/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "deployments/icesat2/image/binder/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
```
Dependabot couldn't update this dependency to the required version as it doesn't support your dependency files.

If you think the above is an error on Dependabot's side, please don't hesitate to get in touch.
```

Maybe from https://github.com/pangeo-data/pangeo-cloud-federation/pull/653/? Trying this out.