### PR TITLE
Fixed GCP Cluster autoscaling

### DIFF
--- a/deployments/gcp-uscentral1b/autoprovisioning.json
+++ b/deployments/gcp-uscentral1b/autoprovisioning.json
@@ -1,7 +1,7 @@
 {
     "resourceLimits": [
-        { "resourceType": "cpu", "minimum": 1, "maximum": 100},
-        { "resourceType": "memory", "minimum": 1, "maximum": 1000},
+        { "resourceType": "cpu", "minimum": 1, "maximum": 400},
+        { "resourceType": "memory", "minimum": 1, "maximum": 1600},
         { "resourceType": "nvidia-tesla-k80", "maximum": 1},
         { "resourceType": "nvidia-tesla-v100", "maximum": 1}
     ],

--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -132,6 +132,14 @@ pangeo:
 
   dask-gateway:
     gateway:
+      backend:
+        worker:
+          extraPodConfig:
+            tolerations:
+              - key: "cloud.google.com/gke-preemptible"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
       extraConfig:
         optionHandler: |
           from dask_gateway_server.options import Options, Integer, Float, String


### PR DESCRIPTION
* Fixes unschedulable pods due to insufficient CPU / memory
* Fixes workers not scheduled on pre-emptible nodes

Closes https://github.com/pangeo-data/pangeo-cloud-federation/issues/656