### PR TITLE
reduce cronjob to nightly

### DIFF
--- a/.github/workflows/UpdateMembers.yml
+++ b/.github/workflows/UpdateMembers.yml
@@ -2,7 +2,7 @@ name: UpdateMembers
 
 on:
   schedule:
-    - cron: "0 * * * *"  #Nightly
+    - cron: "0 0 * * *"  # Nightly at midnight
 
 jobs:
   update-members:


### PR DESCRIPTION
New action is working well:
https://github.com/pangeo-data/pangeo-cloud-federation/runs/902926341?check_suite_focus=true 

But accidentally had it running once per hour instead of once per day