### PR TITLE
different profile lists for staging and prod

### DIFF
--- a/deployments/icesat2/config/common.yaml
+++ b/deployments/icesat2/config/common.yaml
@@ -12,31 +12,8 @@ pangeo:
       continuous:
         enabled: false
     singleuser:
-      profileList:
-        - display_name: "Standard environment"
-          description: "https://github.com/pangeo-data/pangeo-cloud-federation/tree/staging/deployments/icesat2/image/binder"
-          default: true
-        - display_name: "ICESat-2 Hackweek 2020"
-          description: "https://github.com/ICESAT-2HackWeek/jupyter-image-2020"
-          kubespawner_override:
-            image: uwhackweeks/icesat2:latest
-        - display_name: "Latest Pangeo-notebook"
-          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/pangeo-notebook"
-          kubespawner_override:
-            image: pangeo/pangeo-notebook:latest
-        - display_name: "Latest Base-notebook"
-          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/base-notebook"
-          kubespawner_override:
-            image: pangeo/base-notebook:latest
-        - display_name: "Latest ML-notebook"
-          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
-          kubespawner_override:
-            image: pangeo/ml-notebook:latest
-            mem_limit: 60G
-            mem_guarantee: 25G
-            environment: {'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility'}
-            tolerations: [{'key': 'nvidia.com/gpu','operator': 'Equal','value': 'present','effect': 'NoSchedule'}]
-            extra_resource_limits: {"nvidia.com/gpu": "1"}
+      image:
+        pullPolicy: 'Always'
       startTimeout: 600
       initContainers:
         - name: change-volume-mount-permissions

--- a/deployments/icesat2/config/prod.yaml
+++ b/deployments/icesat2/config/prod.yaml
@@ -9,6 +9,28 @@ pangeo:
       extraEnv:
         OAUTH_CALLBACK_URL: "https://aws-uswest2.pangeo.io/hub/oauth_callback"
     singleuser:
+      profileList:
+        - display_name: "Latest Pangeo-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/releases"
+          kubespawner_override:
+            image: pangeo/pangeo-notebook:latest
+        - display_name: "Latest Base-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/releases"
+          kubespawner_override:
+            image: pangeo/base-notebook:latest
+        - display_name: "Latest ML-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/releases"
+          kubespawner_override:
+            image: pangeo/ml-notebook:latest
+            mem_limit: 60G
+            mem_guarantee: 25G
+            environment: {'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility'}
+            tolerations: [{'key': 'nvidia.com/gpu','operator': 'Equal','value': 'present','effect': 'NoSchedule'}]
+            extra_resource_limits: {"nvidia.com/gpu": "1"}
+        - display_name: "ICESat-2 Hackweek 2020"
+          description: "https://github.com/ICESAT-2HackWeek/jupyter-image-2020"
+          kubespawner_override:
+            image: uwhackweeks/icesat2:latest
       extraEnv:
         DASK_GATEWAY__ADDRESS: "https://aws-uswest2.pangeo.io/services/dask-gateway"
         DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-icesat2-prod-dask-gateway.icesat2-prod:80"

--- a/deployments/icesat2/config/staging.yaml
+++ b/deployments/icesat2/config/staging.yaml
@@ -17,6 +17,32 @@ pangeo:
       extraEnv:
         OAUTH_CALLBACK_URL: "https://staging.aws-uswest2.pangeo.io/hub/oauth_callback"
     singleuser:
+      profileList:
+        - display_name: "Staging Pangeo-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/pangeo-notebook"
+          kubespawner_override:
+            image: pangeo/pangeo-notebook:master
+        - display_name: "Latest Pangeo-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/releases"
+          kubespawner_override:
+            image: pangeo/pangeo-notebook:latest
+        - display_name: "Staging Base-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/base-notebook"
+          kubespawner_override:
+            image: pangeo/base-notebook:master
+        - display_name: "Staging ML-notebook"
+          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
+          kubespawner_override:
+            image: pangeo/ml-notebook:master
+            mem_limit: 60G
+            mem_guarantee: 25G
+            environment: {'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility'}
+            tolerations: [{'key': 'nvidia.com/gpu','operator': 'Equal','value': 'present','effect': 'NoSchedule'}]
+            extra_resource_limits: {"nvidia.com/gpu": "1"}
+        - display_name: "ICESat-2 Hackweek 2020"
+          description: "https://github.com/ICESAT-2HackWeek/jupyter-image-2020"
+          kubespawner_override:
+            image: uwhackweeks/icesat2:latest
       extraEnv:
         DASK_GATEWAY__ADDRESS: "https://staging.aws-uswest2.pangeo.io/services/dask-gateway"
         DASK_GATEWAY__PROXY_ADDRESS: "gateway://traefik-icesat2-staging-dask-gateway.icesat2-staging:80"


### PR DESCRIPTION
This should hopefully easy the current staging--> prod testing for hubs using a profile list. Discussed in https://github.com/pangeo-data/pangeo-cloud-federation/issues/690

@TomAugspurger, @jhamman, @rabernat is this something you want to do for the GCP hub? In particular hydro.pangeo.io previous had the GPU option...

