### PR TITLE
Fixed GCP image

### DIFF
--- a/deployments/gcp-uscentral1b/config/common.yaml
+++ b/deployments/gcp-uscentral1b/config/common.yaml
@@ -5,10 +5,8 @@ daskhub:
         nodeAffinity:
           matchNodePurpose: require
     singleuser:
-      # XXX: Hubploy should handle the image stuff
       image:
-        name: pangeo/pangeo-notebook
-        tag: b261b3e
+        pullPolicy: 'Always'
 
       initContainers:
         - name: volume-mount-hack


### PR DESCRIPTION
In https://github.com/pangeo-data/pangeo-cloud-federation/pull/626 *somebody* (me) pinned the image and forgot to remove that pin. That means we're not picking up changes to the environment in `gcp-uscentral1b/image/`. I think hubploy sets this for us, so it shouldn't be needed. It builds and pushes to `us.gcr.io/*************/ocean-pangeo-io-notebook:a483ec4`, but we were pulling `pangeo/pange-notebook`.