### PR TITLE
export the credential file location env variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
           name: Add Runner IP to EKS Kubernetes API Whitelist
           when: always
           command: |
-            AWS_SHARED_CREDENTIALS_FILE=./deployments/icesat2/secrets/aws-config.txt
+            export AWS_SHARED_CREDENTIALS_FILE=./deployments/icesat2/secrets/aws-config.txt
             RUNNERIP=`curl --silent https://checkip.amazonaws.com`
             aws --version
             aws eks update-cluster-config --region us-west-2 --name pangeo --resources-vpc-config publicAccessCidrs=${RUNNERIP}/32 > /dev/null


### PR DESCRIPTION
So the CI system has been failing on the step that is supposed to update the IP addresses that are allowed to access the AWS cluster. Here is the code and the response:

```
#!/bin/bash -eo pipefail
AWS_SHARED_CREDENTIALS_FILE=./deployments/icesat2/secrets/aws-config.txt
RUNNERIP=`curl --silent https://checkip.amazonaws.com`
aws --version
aws eks update-cluster-config --region us-west-2 --name pangeo --resources-vpc-config publicAccessCidrs=${RUNNERIP}/32 > /dev/null
sleep 120
```

```
aws-cli/1.18.140 Python/3.7.2 Linux/4.15.0-1077-aws botocore/1.17.63
Unable to locate credentials. You can configure credentials by running "aws configure".

Exited with code exit status 255
CircleCI received exit code 255
```

@TomAugspurger do you think this commit will make a difference? I know there are differences in using `export` vs not, so if the `update-cluster-config` command spawns a new process, it might not be getting the value of the env variable, thus the "Unable to locate credentials."

My other thought is that somehow it might still be `git-crypt`'d, but that seems unlikely.