### PR TITLE
Restore Gateway tolerations

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -56,6 +56,15 @@ daskhub:
         scheduler:
           extraPodConfig:
             serviceAccountName: pangeo
+            tolerations:
+              - key: "k8s.dask.org/dedicated"
+                operator: "Equal"
+                value: "scheduler"
+                effect: "NoSchedule"
+              - key: "k8s.dask.org_dedicated"
+                operator: "Equal"
+                value: "scheduler"
+                effect: "NoSchedule"
         worker:
           extraContainerConfig:
             securityContext:
@@ -66,6 +75,15 @@ daskhub:
             automountServiceAccountToken: true
             securityContext:
               fsGroup: 1000
+            tolerations:
+              - key: "k8s.dask.org/dedicated"
+                operator: "Equal"
+                value: "worker"
+                effect: "NoSchedule"
+              - key: "k8s.dask.org_dedicated"
+                operator: "Equal"
+                value: "worker"
+                effect: "NoSchedule"
 
         # TODO: figure out a replacement for userLimits.
       extraConfig:


### PR DESCRIPTION
This may be the cause of the schedulers / workers not starting. They
were dropped during the daskhub migration.