### PR TITLE
Updated hubploy and boto3 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jupyter-repo2docker>=0.10.0
 pygithub
 azure-cli
 awscli>=1.18
+boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/yuvipanda/hubploy@d619b2da6cae00c1b14b05b176fb66a5413eb01f
+git+https://github.com/yuvipanda/hubploy@6742809fc1d8676859fe5442478c95c41c7ad050
 jupyter-repo2docker>=0.10.0
 pygithub
 azure-cli


### PR DESCRIPTION
See discussion in https://github.com/pangeo-data/pangeo-cloud-federation/pull/738; I think the new version of `hubploy` and the AWS hub's dynamic IP allowing should work together now.

@TomAugspurger I see you were merging some things as well, let me know if you'd like me to wait on this for now.