### PR TITLE
Add export to the env var command to revert the IP whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
           name: Revert to Original EKS IP Whitelist
           when: always
           command: |
-            AWS_SHARED_CREDENTIALS_FILE=./deployments/icesat2/secrets/aws-config.txt
+            export AWS_SHARED_CREDENTIALS_FILE=./deployments/icesat2/secrets/aws-config.txt
             aws eks update-cluster-config --region us-west-2 --name pangeo --resources-vpc-config publicAccessCidrs=${AWS_IP_WHITELIST} > /dev/null
 
       - run:


### PR DESCRIPTION
Well the first part of the dynamic IP whitelisting worked: https://app.circleci.com/pipelines/github/pangeo-data/pangeo-cloud-federation/1360/workflows/b92914d1-e9b6-4a09-9dd4-addac22bd098/jobs/1520

I just forgot to add `export` to the second command.