### PR TITLE
Test deployments 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,23 +182,7 @@ jobs:
           command: |
             hubploy deploy gcp-uscentral1b pangeo-deploy ${CIRCLE_BRANCH} --cleanup-on-fail --namespace ${CIRCLE_BRANCH}
             # Test the deployment
-            curl -LO "https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl"
-            chmod +x kubectl
-
-            export TOKEN=JUPYTERHUB_TOKEN_GCP_USCENTRAL1B_${CIRCLE_BRANCH}
-            if [[ CIRCLE_BRANCH == "staging" ]]; then
-              export JUPYTERHUB_URL="https://staging.us-central1-b.gcp.pangeo.io"
-            else
-              export JUPYTERHUB_URL="https://us-central1-b.gcp.pangeo.io"
-            fi
-            # Start a JupyterHub server
-            curl -X POST -H "Authorization: token ${TOKEN}" "${JUPYTERHUB_URL}/hub/api/users/pangeo-bot/server"
-            # Copy the test file
-            ./kubectl -n ${CIRCLE_BRANCH} cp test.py jupyter-pangeo-bot:/tmp/test.py
-            # Run the tests
-            ./kubectl -n staging exec jupyter-pangeo-bot /srv/conda/envs/notebook/bin/pytest /tmp/test.py
-            # Cleanup
-            curl -X DELETE -H "Authorization: token ${TOKEN}" "${JUPYTERHUB_URL}/hub/api/users/pangeo-bot/server"
+            python test.py gcp-uscentral1b
 
       # NOTE: should move the dynamic IP into hubploy where credentials and awscli version already dealt with
       # sleep 2min for now, but better to poll for readiness https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -19,10 +19,10 @@ while [[ $(./kubectl -n ${CIRCLE_BRANCH} get pods jupyter-pangeo-2dbot -o 'jsonp
 # Run the tests
 echo "[Running tests]"
 ./kubectl -n staging exec jupyter-pangeo-2dbot /srv/conda/envs/notebook/bin/pytest /tmp/test.py
-
+RET=$?
 
 echo "[Cleaning up]"
 # Cleanup
 curl -X DELETE -H "Authorization: token ${TOKEN}" "${JUPYTERHUB_URL}/hub/api/users/pangeo-bot/server"
 
-
+exit $RET

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+export TOKEN=${JUPYTERHUB_TOKEN_GCP_USCENTRAL1B_STAGING}
+
+if [[ ${CIRCLE_BRANCH} == "staging" ]]; then
+  export JUPYTERHUB_URL="https://staging.us-central1-b.gcp.pangeo.io"
+else
+  export JUPYTERHUB_URL="https://us-central1-b.gcp.pangeo.io"
+fi
+
+# Start a server
+echo "[Staring singleuser server]"
+curl -X POST -H "Authorization: token ${TOKEN}" ${JUPYTERHUB_URL}/hub/api/users/pangeo-bot/server
+
+while [[ $(./kubectl -n ${CIRCLE_BRANCH} get pods jupyter-pangeo-2dbot -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod" && sleep 1; done
+
+# Copy the test file
+./kubectl -n ${CIRCLE_BRANCH} cp test.py jupyter-pangeo-2dbot:/tmp/test.py
+
+# Run the tests
+echo "[Running tests]"
+./kubectl -n staging exec jupyter-pangeo-2dbot /srv/conda/envs/notebook/bin/pytest /tmp/test.py
+
+
+echo "[Cleaning up]"
+# Cleanup
+curl -X DELETE -H "Authorization: token ${TOKEN}" "${JUPYTERHUB_URL}/hub/api/users/pangeo-bot/server"
+
+

--- a/test.py
+++ b/test.py
@@ -1,10 +1,6 @@
 import dask_gateway
 
 
-def inc(x):
-    return x + 1
-
-
 class TestCommon:
     """Tests that should run on all deployments"""
 
@@ -14,11 +10,21 @@ class TestCommon:
         cluster.scale(1)
         client.wait_for_workers(1)
 
-        result = client.map(inc, range(2))
-        result = client.gather(result)
-
 
 class TestGCP:
     """GCP-specific tests"""
     def test_scratch_bucket(self):
-        pass
+        assert 0  # deliberately fail for now.
+
+
+if __name__ == "__main__":
+    # We use kubectl to copy and exec the tests on a singleuser
+    # server. This needs a kubeconfig, and so we call this,
+    # use hubploy to handle auth, and call the tests in a subprocess.
+    import sys
+    import subprocess
+    import hubploy.auth
+
+    deployment = sys.argv[1]
+    with hubploy.auth.cluster_auth(deployment):
+        subprocess.check_output(['./run_tests.sh'])


### PR DESCRIPTION
This is hacky, but will hopefully get the job done. We use kubectl to `exec` the tests in a running singleuser pod. But we need a valid kubeconfig for kubectl to work. Hubploy handles that, so we end up calling a python script that imports hubploy that shells out to a script that `kubectl excecs` pytest on the running pod. I'm aware that that last sentence in nonsense.