### PR TITLE
Env mapping

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -115,7 +115,7 @@ daskhub:
                   Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
                   Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
                   String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
-                  Mapping("environ", {}, label="Environment Variables"),
+                  Mapping("environment", {}, label="Environment Variables"),
                   handler=option_handler,
               )
           c.Backend.cluster_options = cluster_options

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -88,35 +88,36 @@ daskhub:
         # TODO: figure out a replacement for userLimits.
       extraConfig:
         optionHandler: |
-          from dask_gateway_server.options import Options, Integer, Float, String
+          from dask_gateway_server.options import Options, Integer, Float, String, Mapping
           def cluster_options(user):
-             def option_handler(options):
-                 if ":" not in options.image:
-                     raise ValueError("When specifying an image you must also provide a tag")
-                 extra_annotations = {
-                     "hub.jupyter.org/username": user.name,
-                     "prometheus.io/scrape": "true",
-                     "prometheus.io/port": "8787",
-                 }
-                 extra_labels = {
-                     "hub.jupyter.org/username": user.name,
-                 }
-                 return {
-                     "worker_cores_limit": options.worker_cores,
-                     "worker_cores": min(options.worker_cores / 2, 1),
-                     "worker_memory": "%fG" % options.worker_memory,
-                     "image": options.image,
-                     "scheduler_extra_pod_annotations": extra_annotations,
-                     "worker_extra_pod_annotations": extra_annotations,
-                     "scheduler_extra_pod_labels": extra_labels,
-                     "worker_extra_pod_labels": extra_labels,
-                 }
-             return Options(
-                 Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
-                 Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
-                 String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
-                 handler=option_handler,
-             )
+              def option_handler(options):
+                  if ":" not in options.image:
+                      raise ValueError("When specifying an image you must also provide a tag")
+                  extra_annotations = {
+                      "hub.jupyter.org/username": user.name,
+                      "prometheus.io/scrape": "true",
+                      "prometheus.io/port": "8787",
+                  }
+                  extra_labels = {
+                      "hub.jupyter.org/username": user.name,
+                  }
+                  return {
+                      "worker_cores_limit": options.worker_cores,
+                      "worker_cores": min(options.worker_cores / 2, 1),
+                      "worker_memory": "%fG" % options.worker_memory,
+                      "image": options.image,
+                      "scheduler_extra_pod_annotations": extra_annotations,
+                      "worker_extra_pod_annotations": extra_annotations,
+                      "scheduler_extra_pod_labels": extra_labels,
+                      "worker_extra_pod_labels": extra_labels,
+                  }
+              return Options(
+                  Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
+                  Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
+                  String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+                  Mapping("environ", {}, label="Environment Variables"),
+                  handler=option_handler,
+              )
           c.Backend.cluster_options = cluster_options
         idle: |
           # timeout after 30 minutes of inactivity


### PR DESCRIPTION
This adds a `Mapping` option for propagating environment variables to scheduler & worker containers.

Apologies for the large diff from reformatting things. The real change is adding the line

`Mapping("environment", {}, label="Environment Variables"),`