### PR TITLE
Patch build action 2

### DIFF
--- a/.github/workflows/build-aws-image.yaml
+++ b/.github/workflows/build-aws-image.yaml
@@ -1,13 +1,6 @@
-name: Build AWS Image
+name: Build and Push AWS Image
 on:
   push:
-    branches:
-      - staging
-      #- prod
-    paths:
-      - 'deployments/icesat2/image/binder/*'
-      - '.github/workflows/build-aws-image.yaml'
-  pull_request:
     branches:
       - staging
       #- prod
@@ -17,7 +10,7 @@ on:
 
 jobs:
   build_aws_image:
-    name: Build AWS Image
+    name: Build and Push AWS Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-build-aws-image.yaml
+++ b/.github/workflows/test-build-aws-image.yaml
@@ -1,0 +1,29 @@
+name: Test Build AWS Image
+on:
+  pull_request_target:
+    branches:
+      - staging
+      #- prod
+    paths:
+      - 'deployments/icesat2/image/binder/*'
+      - '.github/workflows/test-build-aws-image.yaml'
+
+jobs:
+  build_aws_image:
+    name: Test Build AWS Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: docker://yuvipanda/hubploy:20200826083951674280
+        name: Unlock git-crypt Secrets
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        with:
+          entrypoint: /bin/bash
+          args: -c "echo ${GIT_CRYPT_KEY} | base64 -d | git crypt unlock - && git crypt status"
+      - uses: docker://yuvipanda/hubploy:20200826083951674280
+        name: Build & Push AWS Image if Needed
+        with:
+          args: build icesat2


### PR DESCRIPTION
This PR isolates the workflows for pushes and pull requests so they are separate. 

The pull request action does not need to push the image. It just needs to test that the image can build successfully. The workflow now triggers on `pull_request_target` to have access to secrets, by suggestion from @TomAugspurger .

The push action file is smaller now because it doesn't have the pull request trigger anymore.