### PR TITLE
Adjust CPU:Memory ratio for autoprovisioning

### DIFF
--- a/deployments/gcp-uscentral1b/autoprovisioning.json
+++ b/deployments/gcp-uscentral1b/autoprovisioning.json
@@ -1,7 +1,7 @@
 {
     "resourceLimits": [
         { "resourceType": "cpu", "minimum": 1, "maximum": 400},
-        { "resourceType": "memory", "minimum": 1, "maximum": 1600},
+        { "resourceType": "memory", "minimum": 1, "maximum": 2400},
         { "resourceType": "nvidia-tesla-k80", "maximum": 1},
         { "resourceType": "nvidia-tesla-v100", "maximum": 1}
     ],

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -125,7 +125,7 @@ daskhub:
                   }
               return Options(
                   Float("worker_cores", 2, min=1, max=16, label="Worker Cores"),
-                  Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
+                  Float("worker_memory", 8, min=1, max=32, label="Worker Memory (GiB)"),
                   String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
                   Mapping("environment", {}, label="Environment Variables"),
                   handler=option_handler,

--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -91,7 +91,7 @@ daskhub:
         # TODO: figure out a replacement for userLimits.
       extraConfig:
         optionHandler: |
-          from dask_gateway_server.options import Options, Integer, Float, String, Mapping
+          from dask_gateway_server.options import Options, Float, String, Mapping
           def cluster_options(user):
               def option_handler(options):
                   if ":" not in options.image:
@@ -104,10 +104,18 @@ daskhub:
                   extra_labels = {
                       "hub.jupyter.org/username": user.name,
                   }
+                  # We multiply the requests by 0.95 to ensure that that they
+                  # pack well onto nodes. Kubernetes reserves a small fraction
+                  # of the memory / CPU for itself, so the common situation of
+                  # a node with 4 cores and a user requesting 4 cores means
+                  # we request just over half of the *allocatable* CPU, and so
+                  # we can't pack more than 1 worker on that node.
+                  # On GCP, the kubernetes requests are ~12% of the CPU.
                   return {
+                      "worker_cores": 0.88 * min(options.worker_cores / 2, 1),
                       "worker_cores_limit": options.worker_cores,
-                      "worker_cores": min(options.worker_cores / 2, 1),
-                      "worker_memory": "%fG" % options.worker_memory,
+                      "worker_memory": "%fG" % (0.95 * options.worker_memory),
+                      "worker_memory_limit": "%fG" % options.worker_memory,
                       "image": options.image,
                       "scheduler_extra_pod_annotations": extra_annotations,
                       "worker_extra_pod_annotations": extra_annotations,
@@ -116,7 +124,7 @@ daskhub:
                       "environment": options.environment,
                   }
               return Options(
-                  Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
+                  Float("worker_cores", 2, min=1, max=16, label="Worker Cores"),
                   Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
                   String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
                   Mapping("environment", {}, label="Environment Variables"),


### PR DESCRIPTION
The high-memory workers we use have a Memory:CPU ratio of ~6:1. This updates the values in `autoprovisioning.json` to reflect that.

We'll need to manually set this using gcloud commands. It's not set as part of CI.