### PR TITLE
Set cluster limits

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -123,6 +123,10 @@ daskhub:
         idle: |
           # timeout after 30 minutes of inactivity
           c.KubeClusterConfig.idle_timeout = 1800
+        limits: |
+          # per Dask cluster limits.
+          c.ClusterConfig.cluster_max_cores = 100
+          c.ClusterConfig.cluster_max_memory = "600 GB"
 
 homeDirectories:
   nfs:


### PR DESCRIPTION
This limits the size of the Dask cluster. There's currently no way to
limit the number of Dask clusters per user, so a single user can still
swamp the kubernetes cluster by making multiple dask clusters.

These values were taken from https://github.com/pangeo-data/pangeo-cloud-federation/pull/508, with the memory usage increased to 600GB to reflect the 6:1 memory:CPU ratio of our nodes on GCP.

@tjcrone @scottyhq do these values seem OK to you? If not I can apply them to just GCP.


closes #812 