### PR TITLE
Default Dask Labextension to Gateway Cluster for all hubs 

### DIFF
--- a/pangeo-deploy/values.yaml
+++ b/pangeo-deploy/values.yaml
@@ -27,6 +27,9 @@ daskhub:
       extraEnv:
         # The default worker image matches the singleuser image.
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+        DASK_DISTRIBUTED__DASHBOARD_LINK: '/user/{JUPYTERHUB_USER}/proxy/{port}/status'
+        DASK_LABEXTENSION__FACTORY__MODULE: 'dask_gateway'
+        DASK_LABEXTENSION__FACTORY__CLASS: 'GatewayCluster'
       serviceAccountName: pangeo
 
     prePuller:


### PR DESCRIPTION
This dask configuration used to be embedded in a dask config file in pangeo Docker images, but was removed in https://github.com/pangeo-data/pangeo-docker-images/pull/152 because it seems better to leave as much dask config as possible up to users. Also, the dashboard proxy link and labextension defaults for dask-gateway are only relevant if you're running images on a JupyterHub.

I tested adding these env vars on the AWS binder and it seems to work as expected (https://github.com/scottyhq/pageodev-binder-image). 

addresses #805 cc @tjcrone @TomAugspurger 