### PR TITLE
Additional metrics cleanup

### DIFF
--- a/deployments/gcp-uscentral1b/config/staging.yaml
+++ b/deployments/gcp-uscentral1b/config/staging.yaml
@@ -28,11 +28,3 @@ daskhub:
         worker:
           extraPodConfig:
             schedulerName: gcp-uscentral1b-staging-user-scheduler
-
-metrics:
-  enabled: true
-
-ingress-nginx:
-  controller:
-    service:
-      loadBalancerIP: "34.121.206.128"

--- a/metrics/ingress-config.yaml
+++ b/metrics/ingress-config.yaml
@@ -16,5 +16,3 @@ controller:
     requests:
       cpu: 0m
       memory: 0Gi
-
-

--- a/pangeo-deploy/Chart.yaml
+++ b/pangeo-deploy/Chart.yaml
@@ -10,7 +10,3 @@ dependencies:
     import-values:
       - child: rbac
         parent: rbac
-  - name: ingress-nginx
-    version: "2.11.3"
-    repository: https://kubernetes.github.io/ingress-nginx
-    condition: metrics.enabled


### PR DESCRIPTION
This removes a few more pieces from the metrics based on
prometheus-operator, which we replaced with separate prometheus and
grafana charts.

The dependency on nginx-ingress caused the stray pods in
https://github.com/pangeo-data/pangeo-cloud-federation/issues/769#issuecomment-723213541,
which were unused.