### PR TITLE
Rebuild AWS image on staging

### DIFF
--- a/deployments/gcp-uscentral1b/image/binder/README.md
+++ b/deployments/gcp-uscentral1b/image/binder/README.md
@@ -1,0 +1,2 @@
+# Default Hub image
+https://github.com/pangeo-data/pangeo-docker-images


### PR DESCRIPTION
After https://github.com/pangeo-data/pangeo-cloud-federation/pull/860

seeing this error
```
2020-11-07 00:36:30+00:00 [Normal] Back-off pulling image "783380859522.dkr.ecr.us-west-2.amazonaws.com/pangeo:9313436d"
```

Seems there is a bug in hubploy with the "rebase and merge strategy" where it is picking up the parent commit to tag the image (c61e11f)
https://github.com/pangeo-data/pangeo-cloud-federation/runs/1366351698?check_suite_focus=true

but deploying is pointing the hub at the most recent commit (9313436)
https://github.com/pangeo-data/pangeo-cloud-federation/runs/1366351748?check_suite_focus=true 


I'll see if this works.  going forward might be necessary to have the 'squash and merge' re-enabled standard merge, or update hubploy... or maybe we need to add back the `--check-registry` flag...
https://github.com/pangeo-data/pangeo-cloud-federation/pull/754#issuecomment-702376677
