### PR TITLE
redeploy is2 if image changes

### DIFF
--- a/.github/workflows/deploy-aws-hub.yaml
+++ b/.github/workflows/deploy-aws-hub.yaml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - staging
-      #- prod
+      - prod
     paths:
       - 'deployments/icesat2/config/**'
+      - 'deployments/icesat2/image/**'
       - 'deployments/icesat2/secrets/**'
       - 'deployments/icesat2/hubploy.yaml'
       - 'pangeo-deploy/**'

--- a/.github/workflows/test-build-aws-image.yaml
+++ b/.github/workflows/test-build-aws-image.yaml
@@ -5,7 +5,7 @@ on:
       - staging
       - prod
     paths:
-      - 'deployments/icesat2/image/binder/*'
+      - 'deployments/icesat2/image/**'
       - '.github/workflows/test-build-aws-image.yaml'
 
 jobs:


### PR DESCRIPTION
#862 triggered a rebuild with the correct image tag (4829bd5)
https://github.com/pangeo-data/pangeo-cloud-federation/actions/runs/350526433 

But the hub still didn't pick it up because the deploy-aws-hub.yaml action was not triggered