### PR TITLE
helm executable typo

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Helm Lint AWS Config
         run: |
-          helm lint --strict pangeo-deploy -f pangeo-deploy/values.yaml \
+          helm3 lint --strict pangeo-deploy -f pangeo-deploy/values.yaml \
                                   -f deployments/icesat2/config/common.yaml \
                                   -f deployments/icesat2/config/staging.yaml \
                                   -f deployments/icesat2/secrets/staging.yaml


### PR DESCRIPTION
Should fix `Helm Lint` github action
https://github.com/pangeo-data/pangeo-cloud-federation/runs/1490765224?check_suite_focus=true 
```
==> Linting pangeo-deploy

[INFO] Chart.yaml: icon is recommended
Warning:  /home/runner/work/pangeo-cloud-federation/pangeo-cloud-federation/pangeo-deploy: chart directory is missing these dependencies: daskhub
Error: Process completed with exit code 1.
```