### PR TITLE
Bump prod images to pangeo/pangeo-notebook:2021.01.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,6 @@ jobs:
             pip install --upgrade -r requirements.txt
 
             curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -C venv/ -xzf -
-            # https://github.com/awslabs/amazon-ecr-credential-helper/issues/101
-            # Can simplify to sudo apt install amazon-ecr-credential-helper if running Ubuntu 19.04 and newer
-            export GOPATH=$PWD/venv
-            go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 
             # Be careful with quote ordering here. ${PATH} must not be expanded
             # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
@@ -164,14 +160,14 @@ jobs:
           name: Install helm
           when: always
           command: |
-            curl https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz | \
+            curl https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz | \
               tar -xzf -
             sudo mv linux-amd64/helm /usr/local/bin
             helm version
             helm repo add dask https://helm.dask.org/
             helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
             helm repo add dask-gateway https://dask.org/dask-gateway-helm-repo/
-            helm repo add stable https://kubernetes-charts.storage.googleapis.com
+            helm repo add stable https://charts.helm.sh/stable
             helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
             helm repo add prometheus-operator https://kubernetes-charts.storage.googleapis.com
             helm repo update

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -37,7 +37,7 @@ jobs:
           # needed for prometheus and grafana
           #helm3 repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm3 repo update
-          helm3 dependency update
+          helm3 dependency update pangeo-deploy 
 
       - name: Helm Lint AWS Config
         run: |

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -37,6 +37,7 @@ jobs:
           # needed for prometheus and grafana
           #helm3 repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm3 repo update
+          helm3 dependency update
 
       - name: Helm Lint AWS Config
         run: |

--- a/deployments/gcp-uscentral1b/image/binder/Dockerfile
+++ b/deployments/gcp-uscentral1b/image/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/pangeo-notebook:2021.01.16
+FROM pangeo/pangeo-notebook:2021.01.24

--- a/deployments/gcp-uscentral1b/image/binder/Dockerfile
+++ b/deployments/gcp-uscentral1b/image/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/pangeo-notebook:2020.12.08
+FROM pangeo/pangeo-notebook:2021.01.16

--- a/deployments/icesat2/image/binder/Dockerfile
+++ b/deployments/icesat2/image/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/pangeo-notebook:2021.01.16
+FROM pangeo/pangeo-notebook:2021.01.24

--- a/deployments/icesat2/image/binder/Dockerfile
+++ b/deployments/icesat2/image/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/pangeo-notebook:2020.12.08
+FROM pangeo/pangeo-notebook:2021.01.16


### PR DESCRIPTION
i'm motivated to do this based on an error on prod with fsspec 0.8.4 `AttributeError: module 'fsspec' has no attribute 'config'` so this would bump to 0.8.5 which seems to be working. 

A full list of changed packages is here: 
https://github.com/pangeo-data/pangeo-docker-images/compare/2020.12.08..2021.01.24#diff-ceee658209456cc3bd347679717bdb5d95ee7fb5a91ffa1dc6d2e2d556144987

cc @TomAugspurger @rabernat 