### PR TITLE
Bump pangeo/pangeo-notebook from 2021.02.02 to 2021.03.27 in /deployments/gcp-uscentral1b/image/binder

### DIFF
--- a/deployments/gcp-uscentral1b/image/binder/Dockerfile
+++ b/deployments/gcp-uscentral1b/image/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/pangeo-notebook:2021.02.02
+FROM pangeo/pangeo-notebook:2021.03.27


### PR DESCRIPTION
This PR is to check whether or not the CI failure over in https://github.com/pangeo-data/pangeo-cloud-federation/pull/944 is due to the changes in that PR or something unrelated. Based on the CircleCI logs I suspect it's not related to the changes in that PR, but thought it was worth checking. 